### PR TITLE
Record Codex trim primitive spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ shipped to npm but were not individually tagged on GitHub.
   shipped in the npm tarball.
 - `.codex-sidecar/logs/` is ignored as a runtime artifact from real sidecar
   smoke runs.
+- Codex trim host status now distinguishes verified app-server rollback/inject
+  primitives from the still-unimplemented Throughline automatic trim execution.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual
@@ -60,6 +62,9 @@ shipped to npm but were not individually tagged on GitHub.
   sidecar diagnostics / dry-run examples reproducible from the package source.
 - `npm test` now includes nested `src/cli/*.test.mjs` coverage in addition to
   the top-level `src/*.test.mjs` tests.
+- Recorded the 2026-05-06 Codex app-server rollback/inject spike: `thread/read`
+  can read persisted threads, `thread/rollback` requires a loaded thread via
+  `thread/resume`, and injected developer items are visible to the next turn.
 
 ## [0.3.24] — 2026-05-02
 

--- a/docs/PUBLIC_RELEASE_PLAN.md
+++ b/docs/PUBLIC_RELEASE_PLAN.md
@@ -118,7 +118,7 @@ schema v4 で PostToolUse (`capture-tool`) は廃止、L2/L3 は Stop 内で一�
 | **npm 公開 (v0.3.24)** | 2026-05-02 v0.3.23 の補完: `.vscode/tasks.json` には現環境の絶対パスが書き込まれるため、**そもそも commit すべきではない**。`shouldRecommendGitignore` を [src/vscode-task.mjs](../src/vscode-task.mjs) に追加し、`ensureMonitorTaskFile` が created / merged / repaired を返すタイミングで「git リポジトリ内かつ `.gitignore` に `.vscode/tasks.json` 系エントリが無い」を判定。該当時に `<system-reminder>` で `.gitignore` 追加推奨を 1 度だけ stdout 通知 (`.throughline-gitignore-noted` marker で抑止)。否定パターン (`!.vscode/tasks.json`) はスキップ判定 = 推奨を出す。README Troubleshooting にも明示。配布物 (npm tarball) には絶対パスは入っていない (`files` フィールドが `.vscode/` を含まない、ソースに hard-coded path 無し) ことを再確認 |
 | **未公開: Claude-primary / Codex-sidecar groundwork** | `HandoffRecord` projection、`throughline handoff-preview`、`throughline_handoff` example、`codex-sidecar-diagnostics` / `codex-sidecar-dry-run` を追加。Claude Code hooks / slash command / transcript / baton / resume behavior は正本として維持し、Codex 対応は adapter / projection として足す |
 | **未公開: optional Codex L1 summarization** | L2→L1 要約は、`codex-sidecar` が `summarize-l1` preset で configured の場合だけ sidecar を使う。disabled / unavailable / run failure では、ユーザー許可済み互換経路として既存 Claude Haiku 要約を維持する。Claude CLI smoke / test で Claude を呼ぶ場合は Haiku を使う |
-| **未公開: `/tl-trim` dry-run** | `throughline trim --dry-run`、`--host`、`--keep-recent`、`--all`、`--memo-stdin`、`throughline doctor --trim`、Claude slash command `/tl-trim` を追加。automatic rollback / inject は未検証 host primitive のため無効。curated memory は current-work memo と active work thread framing を含み、L2 を単なる過去ログとして読ませない |
+| **未公開: `/tl-trim` dry-run** | `throughline trim --dry-run`、`--host`、`--keep-recent`、`--all`、`--memo-stdin`、`throughline doctor --trim`、Claude slash command `/tl-trim` を追加。Codex app-server の rollback / inject primitive は実測済みだが、Throughline CLI から対象 thread を安全に制御する統合は未実装のため automatic rollback / inject は無効。curated memory は current-work memo と active work thread framing を含み、L2 を単なる過去ログとして読ませない |
 | **未公開: npm docs packaging** | README から参照する `docs/` と `CHANGELOG.md` を npm `files` に追加。`docs/throughline-handoff-context.example.json` を含め、README の sidecar dry-run 例が tarball 内でも成立するようにする |
 | **グローバル E2E 検証** | 2026-04-17 別ディレクトリから `throughline doctor` 全緑を確認 |
 
@@ -131,7 +131,7 @@ schema v4 で PostToolUse (`capture-tool`) は廃止、L2/L3 は Stop 内で一�
 | **GitHub Actions 自動 publish** | `release` タグ push をトリガー（Phase 3+、Trusted Publishing 使用） |
 | **Claude Code プラグインマーケットプレース登録** | npm 公開の後継ステップ（Phase 3+） |
 | **turn-processor.test.mjs の 10 秒タイムアウト解消** | `main()` が stdin を待ち続けるためテストファイルがハングする既存の問題。実装動作は無影響、テスト個別 9/9 は pass |
-| **automatic context rollback / inject** | Claude / Codex いずれも host primitive の自動実行は未検証。現時点では `/tl-trim` dry-run と手動手順に留める |
+| **automatic context rollback / inject** | Codex host primitive は実測済み。残る本線タスクは Throughline 側の current thread identity / app-server integration harness。Claude は引き続き `/rewind conversation only` の手動 UX 扱い。現時点では `/tl-trim` dry-run と手動手順に留める |
 
 ---
 

--- a/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
+++ b/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
@@ -43,7 +43,7 @@ rollback trim は最終的な理想に近いが、host primitive の実測が必
 - Claude hooks、slash command、transcript parsing、handoff baton、SessionStart resume behavior を Codex 用に置き換えない。
 - Claude-facing field / command / DB semantics を rename しない。
 - Codex 対応は adapter / projection として足す。
-- 未検証の `thread/rollback` / `thread/inject_items` 挙動を確定仕様として扱わない。
+- `thread/rollback` / `thread/inject_items` は host primitive として実測済み。ただし Throughline CLI から安全に現在 thread を特定して実行する統合が入るまで、本線 UX では自動 rollback / inject を有効化しない。
 - fallback や silent recovery で失敗を隠さない。互換モードは条件と理由を明示する。
 
 ## 運用ルール
@@ -335,17 +335,17 @@ Phase 5 implementation result (2026-05-06):
 
 Codex spike TODO:
 
-- [ ] 小さな test thread を開始する。
-- [ ] 複数 turn を作る。
-- [ ] Codex の host identity model を記録する。`thread_id`、turn index、rollout JSONL、project path の対応を確認する。
-- [ ] `thread/rollback` を partial `numTurns` で呼ぶ。
-- [ ] `thread/rollback` を full または near-full `numTurns` で呼ぶ。
-- [ ] rollback 後の `thread/read includeTurns:true` を確認する。
-- [ ] rollback 後の rollout JSONL を確認する。
-- [ ] `thread/inject_items` に最小 memory item を渡す。
-- [ ] 次 turn で injected memory が model-visible か確認する。
+- [x] 小さな test thread を開始する。
+- [ ] 複数 turn を作る。単一 turn の full rollback は検証済み。partial rollback は Throughline 統合実装時の harness で追加検証する。
+- [x] Codex の host identity model を記録する。`thread_id`、turn index、rollout JSONL、project path の対応を確認する。
+- [ ] `thread/rollback` を partial `numTurns` で呼ぶ。複数 turn harness 未作成のため未完了。
+- [x] `thread/rollback` を full または near-full `numTurns` で呼ぶ。
+- [x] rollback 後の `thread/read includeTurns:true` を確認する。
+- [x] rollback 後の rollout JSONL を確認する。
+- [x] `thread/inject_items` に最小 memory item を渡す。
+- [x] 次 turn で injected memory が model-visible か確認する。
 - [ ] `thread/resume` 後も rollback marker と injected memory が効くか確認する。
-- [ ] ローカルファイル変更が戻らないことを確認する。
+- [ ] ローカルファイル変更が戻らないことを確認する。schema 上は conversation history only と明記されるが、Throughline 統合 harness で実ファイル変更を含めて確認する。
 
 Claude spike TODO:
 
@@ -363,13 +363,18 @@ Claude spike TODO:
 Phase 6 result (2026-05-06):
 
 - `codex-sidecar` read-only `explore` smoke と `review` / `risk-check` dry-run は成功。
-- Codex `thread/rollback` / `thread/inject_items` を Throughline から安全に呼べる host primitive は未検証。Codex host の automatic rollback / inject は `unresolved`。
+- Codex CLI `0.128.0-alpha.1` の app-server schema で `thread/read`、`thread/resume`、`thread/rollback`、`thread/inject_items`、`turn/start` を確認した。
+- `stdio://` transport は newline-delimited JSON で実測通過した。`initialize` 後に `thread/read includeTurns:true` が persisted thread を読める。
+- `thread/rollback` は persisted thread を直接対象にすると `thread not found` を返す。`thread/resume` で loaded thread にしてから呼ぶ必要がある。
+- 検証 thread `019dfaba-f87e-7f41-a144-d5ca7c6dd7f9` で、1 turn を `thread/rollback { numTurns: 1 }` し、`thread/read includeTurns:true` が 0 turns を返すことを確認した。
+- `thread/inject_items` に raw Responses API item `{ type: "message", role: "developer", content: [{ type: "input_text", text: "..." }] }` を渡し、次の `turn/start` で injected memory が model-visible になることを確認した。marker `TL_PHASE6_INJECT_OK` を正しく返した。
+- Codex host primitive は `verified-host-primitive`。ただし Throughline CLI から安全に「現在操作すべき Codex thread」を特定して制御する統合は未実装なので、Codex host の automatic rollback / inject はまだ有効化しない。
 - Claude `/rewind conversation only` は手動 UX として扱う。外部ツールからの自動化 surface は未確認。Claude host の automatic rollback / inject は `manual-only`。
-- このため Phase 8 は自動 rollback 実装に進まず、dry-run / 手動案内までに留める。
+- このため Phase 8 は Codex app-server integration harness を追加するまで non-dry-run を拒否し、dry-run / 手動案内までに留める。
 
 完了条件:
 
-- [x] rollback trim を自動実装してよい host と、手動案内に留める host が判断できる。
+- [x] rollback trim を自動実装してよい host と、手動案内に留める host が判断できる。Codex は primitive 済みだが Throughline 統合未完了、Claude は manual-only。
 
 ## Phase 7: Trim Handoff Model
 
@@ -377,7 +382,7 @@ Phase 6 result (2026-05-06):
 
 TODO:
 
-- [x] host identity model を整理する。Claude `session_id`、Codex `thread_id`、`project_path`、origin session / thread references の対応表を作る。Phase 6 で未検証の host は `unknown / unresolved` として扱い、自動 rollback 対応 host に含めない。
+- [x] host identity model を整理する。Claude `session_id`、Codex `thread_id`、`project_path`、origin session / thread references の対応表を作る。Codex は `thread_id` と rollout JSONL を app-server で扱えるが、Throughline CLI が現在 thread を誤認しない統合が入るまで自動 rollback 対応 host に含めない。
 - [x] current session / thread の captured turn count を記録または導出する方法を決める。
 - [x] rollback 可能な最大 turn 数を計算する。
 - [x] keep-recent の既定値を決める。
@@ -417,14 +422,14 @@ TODO:
 - [x] `/tl-trim --dry-run` を先に実装する。
 - [x] host が自動 rollback 非対応の場合、明示的な手動手順を返す。
 - [x] 実行前に captured turns / keep turns / injected memory summary を表示する。
-- [ ] 自動 rollback 対応 host では、実行後に resume / injected memory が有効か検証する。未対応 / unresolved host ではこの検証を要求しない。
+- [ ] 自動 rollback 対応 host では、実行後に resume / injected memory が有効か検証する。Codex は primitive 検証済みだが、Throughline 統合 harness までは未対応 host として扱う。
 - [x] `doctor` に trim 関連診断を追加する。
 
 Phase 8 partial implementation result (2026-05-06):
 
 - `throughline trim --dry-run [--host claude|codex|unknown] [--keep-recent N] [--all] [--session <id>] [--json]` を追加。
 - `throughline trim --dry-run --memo-stdin` を追加。`/tl` が解決した「L1/L2 はあるが今やっている作業として認識されない」問題を `/tl-trim` でも再発させないため、current-work memo を curated memory preview の先頭に入れる。
-- non-dry-run `throughline trim` は automatic rollback / inject 未検証のため exit 1 で明示拒否する。
+- non-dry-run `throughline trim` は automatic rollback / inject の Throughline 統合が未実装のため exit 1 で明示拒否する。Codex primitive 自体は検証済みだが、現在 thread の明示制御が入るまで実行しない。
 - Claude slash command [.claude/commands/tl-trim.md](../.claude/commands/tl-trim.md) を追加し、現行 Claude が current-work memo を書いてから `throughline trim --dry-run --host claude --memo-stdin` を呼ぶ dry-run UX にした。
 - `throughline install` / `uninstall` は `/tl-trim` も配布 / 削除する。
 - `throughline doctor --trim --host claude|codex|unknown` を追加し、default keep-recent、automatic rollback / inject 可否、manual procedure を表示する。

--- a/docs/throughline-rollback-context-trim-insight.md
+++ b/docs/throughline-rollback-context-trim-insight.md
@@ -13,6 +13,8 @@
 
 この文書は「rollback は欠けていた delete primitive かもしれない」という洞察を残すもの。実装時は、未検証の host primitive を本線仕様にせず、統合計画の Phase 6 で実測してから `/tl-trim` 系 UX に進む。
 
+2026-05-06 update: Codex app-server の `thread/rollback` / `thread/inject_items` は host primitive として実測済み。ただし Throughline CLI から安全に現在 thread を特定し、誤 thread を trim しない統合は未実装なので、non-dry-run `/tl-trim` はまだ有効化しない。
+
 ## 概要
 
 Throughline はもともと、ホスト側の制約に対する回避策として作られた。
@@ -158,6 +160,17 @@ Codex CLI / app-server documentation から確認できたもの:
 - rollback の説明では、thread history のみを変更し、ローカルファイル変更は戻さないとされている。
 
 つまり Codex の `thread/rollback` は、かなり conversation-only rollback に近い。
+
+2026-05-06 の実測:
+
+- Codex CLI `0.128.0-alpha.1` で `stdio://` app-server は newline-delimited JSON request / response で操作できた。
+- `thread/read includeTurns:true` は persisted thread を読める。
+- `thread/rollback` は loaded thread にだけ効く。persisted thread に直接呼ぶと `thread not found`。
+- `thread/resume` 後に `thread/rollback { numTurns: 1 }` を呼ぶと、1 turn の検証 thread は 0 turns になった。
+- rollback 後に `thread/inject_items` へ developer message item を入れ、次の `turn/start` で marker `TL_PHASE6_INJECT_OK` が model-visible になった。
+- rollout JSONL には injected item が developer role の response item として記録された。
+
+残る未検証は、複数 turn の partial rollback、rollback marker の resume 後挙動、ローカルファイル変更が戻らないことの実ファイル付き smoke、UI 表示差分。
 
 参考:
 
@@ -339,10 +352,10 @@ memory を保存する
 
 Codex:
 
-- `thread/rollback` は thread 内の全turn数と同じ `numTurns` を受け入れるか。
-- 受け入れない場合、最低限残さなければならない履歴は何か。
-- `thread/inject_items` は次の model-visible context に確実に入るか。
-- `thread/inject_items` が受け付ける正確な Responses API item 形式は何か。
+- 複数 turn thread で `thread/rollback` の partial `numTurns` が期待通りに効くか。
+- `thread/rollback` は thread 内の全turn数と同じ `numTurns` を受け入れるか。単一 turn の full rollback は成功済み。
+- `thread/inject_items` は次の model-visible context に確実に入るか。developer message item では成功済み。
+- `thread/inject_items` が受け付ける Responses API item 形式の許容範囲は何か。developer message item は成功済み。
 - rollback 後、UI履歴はどう見えるか。消えるのか、marker付きで残るのか。
 - rollback marker は `thread/resume` 後も期待通りに効くか。
 - full rollback が token accounting を壊したり、不要な auto-compaction を誘発しないか。
@@ -391,7 +404,7 @@ Claude:
 
 推奨する次の検証:
 
-1. 小さな Codex app-server spike を作る。
+1. 小さな Codex app-server integration harness を Throughline 側に作る。
 2. test thread を開始し、数turn実行する。
 3. turn を最小Throughline風DBまたはJSONへ捕捉する。
 4. `thread/rollback` を partial `numTurns` で呼ぶ。
@@ -408,6 +421,7 @@ Claude:
 full または near-full rollback が動く。
 ローカルファイル変更は維持される。
 injected curated memory が次の model turn から見える。
+Throughline が対象 Codex thread を明示的に識別でき、誤 thread を rollback しない。
 標準 compaction は不要。
 同じ thread / session で続行できる。
 ```

--- a/src/trim-cli.test.mjs
+++ b/src/trim-cli.test.mjs
@@ -77,7 +77,7 @@ test('trim CLI prints JSON dry-run plan for latest project session', async () =>
   }
 });
 
-test('trim CLI refuses non-dry-run execution while host primitives are unresolved', async () => {
+test('trim CLI refuses non-dry-run execution until automatic trim integration exists', async () => {
   const home = makeTempHome();
   const project = makeTempProject();
   try {

--- a/src/trim-model.mjs
+++ b/src/trim-model.mjs
@@ -88,12 +88,12 @@ export function describeTrimHost(host) {
       host,
       automaticRollback: false,
       automaticInject: false,
-      status: 'unresolved',
-      reason: 'codex_thread_rollback_inject_not_verified_for_throughline',
+      status: 'verified-host-primitive',
+      reason: 'codex_thread_rollback_inject_verified_but_not_integrated',
       manualProcedure: [
         'Run this dry-run first and review the rollback / injection plan.',
-        'Do not call thread/rollback or thread/inject_items from Throughline until Phase 6 host primitive verification is complete.',
-        'Use the current Codex session directly unless an explicit, verified host boundary is available.',
+        'Codex app-server thread/rollback and thread/inject_items are verified host primitives.',
+        'Do not run automatic trim until Throughline can identify and control the intended Codex thread explicitly.',
       ],
     };
   }

--- a/src/trim-model.test.mjs
+++ b/src/trim-model.test.mjs
@@ -110,8 +110,8 @@ test('buildTrimPlan: --all plans to roll back every captured turn without enabli
     trimAll: true,
   });
 
-  assert.equal(plan.status, 'unresolved');
-  assert.equal(plan.host.reason, 'codex_thread_rollback_inject_not_verified_for_throughline');
+  assert.equal(plan.status, 'verified-host-primitive');
+  assert.equal(plan.host.reason, 'codex_thread_rollback_inject_verified_but_not_integrated');
   assert.equal(plan.trim.keepRecent, 0);
   assert.equal(plan.trim.rollbackTurns, 3);
   assert.equal(plan.trim.automaticExecutionAllowed, false);


### PR DESCRIPTION
## Summary
- Record the 2026-05-06 Codex app-server rollback/inject spike in the trim implementation docs.
- Update Codex trim host status from unresolved to verified host primitive, while keeping automatic Throughline trim disabled until current-thread control is integrated.
- Refresh trim tests and release planning notes for the new boundary state.

## Verification
- npm test (291 pass)
- git diff --check
- node bin/throughline.mjs doctor --trim --host codex