### PR TITLE
Add Codex app-server protocol helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ shipped to npm but were not individually tagged on GitHub.
 - `/tl-trim` dry-run surface:
   `throughline trim --dry-run`, `--host`, `--keep-recent`, `--all`,
   `--memo-stdin`, and `throughline doctor --trim`.
+- Codex app-server protocol helpers for the verified trim flow: newline JSON
+  framing, initialize / resume / rollback / inject / turn-start request
+  builders, and parser coverage.
 
 ### Changed
 - Resume context now frames recent L2 as an active work thread with explicit

--- a/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
+++ b/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
@@ -430,6 +430,7 @@ Phase 8 partial implementation result (2026-05-06):
 - `throughline trim --dry-run [--host claude|codex|unknown] [--keep-recent N] [--all] [--session <id>] [--json]` を追加。
 - `throughline trim --dry-run --memo-stdin` を追加。`/tl` が解決した「L1/L2 はあるが今やっている作業として認識されない」問題を `/tl-trim` でも再発させないため、current-work memo を curated memory preview の先頭に入れる。
 - non-dry-run `throughline trim` は automatic rollback / inject の Throughline 統合が未実装のため exit 1 で明示拒否する。Codex primitive 自体は検証済みだが、現在 thread の明示制御が入るまで実行しない。
+- `src/codex-app-server.mjs` を追加し、newline JSON framing、initialize / read / resume / rollback / inject / turn-start request builder、server line parser をテストで固定した。これは実行統合の足場であり、まだ non-dry-run trim を有効化しない。
 - Claude slash command [.claude/commands/tl-trim.md](../.claude/commands/tl-trim.md) を追加し、現行 Claude が current-work memo を書いてから `throughline trim --dry-run --host claude --memo-stdin` を呼ぶ dry-run UX にした。
 - `throughline install` / `uninstall` は `/tl-trim` も配布 / 削除する。
 - `throughline doctor --trim --host claude|codex|unknown` を追加し、default keep-recent、automatic rollback / inject 可否、manual procedure を表示する。

--- a/src/codex-app-server.mjs
+++ b/src/codex-app-server.mjs
@@ -1,0 +1,248 @@
+export const CODEX_APP_SERVER_METHODS = Object.freeze({
+  initialize: 'initialize',
+  initialized: 'initialized',
+  threadRead: 'thread/read',
+  threadResume: 'thread/resume',
+  threadRollback: 'thread/rollback',
+  threadInjectItems: 'thread/inject_items',
+  turnStart: 'turn/start',
+});
+
+export function encodeAppServerMessage(message) {
+  if (!isRecord(message)) {
+    throw new Error('encodeAppServerMessage: message must be an object');
+  }
+  return `${JSON.stringify(message)}\n`;
+}
+
+export function parseAppServerLine(line) {
+  if (typeof line !== 'string') {
+    throw new Error('parseAppServerLine: line must be a string');
+  }
+
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error('parseAppServerLine: line must not be empty');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    throw new Error(`parseAppServerLine: invalid JSON: ${msg}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('parseAppServerLine: decoded message must be an object');
+  }
+
+  if ('error' in parsed && 'id' in parsed) {
+    if (!isRequestId(parsed.id) || !isRecord(parsed.error)) {
+      throw new Error('parseAppServerLine: invalid error response');
+    }
+    const { code, message, data } = parsed.error;
+    if (typeof code !== 'number' || typeof message !== 'string') {
+      throw new Error('parseAppServerLine: invalid error response');
+    }
+    return {
+      kind: 'error',
+      id: parsed.id,
+      error: { code, message, data },
+    };
+  }
+
+  if ('result' in parsed && 'id' in parsed) {
+    if (!isRequestId(parsed.id)) {
+      throw new Error('parseAppServerLine: invalid response id');
+    }
+    return {
+      kind: 'response',
+      id: parsed.id,
+      result: parsed.result,
+    };
+  }
+
+  if (typeof parsed.method === 'string') {
+    if ('id' in parsed) {
+      if (!isRequestId(parsed.id)) {
+        throw new Error('parseAppServerLine: invalid server request id');
+      }
+      return {
+        kind: 'request',
+        id: parsed.id,
+        method: parsed.method,
+        params: parsed.params,
+      };
+    }
+    return {
+      kind: 'notification',
+      method: parsed.method,
+      params: parsed.params,
+    };
+  }
+
+  throw new Error('parseAppServerLine: unrecognized message shape');
+}
+
+export function buildInitializeRequest({
+  id,
+  clientName = 'throughline',
+  clientTitle = 'Throughline',
+  version = '0.0.0',
+  optOutNotificationMethods = [],
+}) {
+  assertRequestId(id, 'buildInitializeRequest');
+  if (!Array.isArray(optOutNotificationMethods)) {
+    throw new Error('buildInitializeRequest: optOutNotificationMethods must be an array');
+  }
+  return {
+    id,
+    method: CODEX_APP_SERVER_METHODS.initialize,
+    params: {
+      clientInfo: {
+        name: clientName,
+        title: clientTitle,
+        version,
+      },
+      capabilities: {
+        experimentalApi: true,
+        optOutNotificationMethods,
+      },
+    },
+  };
+}
+
+export function buildInitializedNotification() {
+  return {
+    method: CODEX_APP_SERVER_METHODS.initialized,
+  };
+}
+
+export function buildThreadReadRequest({ id, threadId, includeTurns = true }) {
+  assertRequestId(id, 'buildThreadReadRequest');
+  assertNonEmptyString(threadId, 'buildThreadReadRequest: threadId');
+  return {
+    id,
+    method: CODEX_APP_SERVER_METHODS.threadRead,
+    params: {
+      threadId,
+      includeTurns: Boolean(includeTurns),
+    },
+  };
+}
+
+export function buildThreadResumeRequest({
+  id,
+  threadId,
+  cwd,
+  approvalPolicy = null,
+  sandbox = null,
+  model = null,
+  excludeTurns = false,
+}) {
+  assertRequestId(id, 'buildThreadResumeRequest');
+  assertNonEmptyString(threadId, 'buildThreadResumeRequest: threadId');
+  return compactNullish({
+    id,
+    method: CODEX_APP_SERVER_METHODS.threadResume,
+    params: compactNullish({
+      threadId,
+      cwd,
+      approvalPolicy,
+      sandbox,
+      model,
+      excludeTurns: Boolean(excludeTurns),
+    }),
+  });
+}
+
+export function buildThreadRollbackRequest({ id, threadId, numTurns }) {
+  assertRequestId(id, 'buildThreadRollbackRequest');
+  assertNonEmptyString(threadId, 'buildThreadRollbackRequest: threadId');
+  if (!Number.isInteger(numTurns) || numTurns < 1) {
+    throw new Error('buildThreadRollbackRequest: numTurns must be an integer >= 1');
+  }
+  return {
+    id,
+    method: CODEX_APP_SERVER_METHODS.threadRollback,
+    params: {
+      threadId,
+      numTurns,
+    },
+  };
+}
+
+export function buildThreadInjectItemsRequest({ id, threadId, items }) {
+  assertRequestId(id, 'buildThreadInjectItemsRequest');
+  assertNonEmptyString(threadId, 'buildThreadInjectItemsRequest: threadId');
+  if (!Array.isArray(items)) {
+    throw new Error('buildThreadInjectItemsRequest: items must be an array');
+  }
+  return {
+    id,
+    method: CODEX_APP_SERVER_METHODS.threadInjectItems,
+    params: {
+      threadId,
+      items,
+    },
+  };
+}
+
+export function buildTurnStartRequest({ id, threadId, text }) {
+  assertRequestId(id, 'buildTurnStartRequest');
+  assertNonEmptyString(threadId, 'buildTurnStartRequest: threadId');
+  assertNonEmptyString(text, 'buildTurnStartRequest: text');
+  return {
+    id,
+    method: CODEX_APP_SERVER_METHODS.turnStart,
+    params: {
+      threadId,
+      input: [buildTextInputItem(text)],
+    },
+  };
+}
+
+export function buildTextInputItem(text) {
+  assertNonEmptyString(text, 'buildTextInputItem: text');
+  return {
+    type: 'text',
+    text,
+    text_elements: [],
+  };
+}
+
+export function buildDeveloperMessageItem(text) {
+  assertNonEmptyString(text, 'buildDeveloperMessageItem: text');
+  return {
+    type: 'message',
+    role: 'developer',
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+function compactNullish(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== null && entry !== undefined),
+  );
+}
+
+function assertRequestId(id, caller) {
+  if (!isRequestId(id)) {
+    throw new Error(`${caller}: id must be a string or integer`);
+  }
+}
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function isRequestId(value) {
+  return typeof value === 'string' || (typeof value === 'number' && Number.isInteger(value));
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/codex-app-server.test.mjs
+++ b/src/codex-app-server.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CODEX_APP_SERVER_METHODS,
+  buildDeveloperMessageItem,
+  buildInitializeRequest,
+  buildInitializedNotification,
+  buildTextInputItem,
+  buildThreadInjectItemsRequest,
+  buildThreadReadRequest,
+  buildThreadResumeRequest,
+  buildThreadRollbackRequest,
+  buildTurnStartRequest,
+  encodeAppServerMessage,
+  parseAppServerLine,
+} from './codex-app-server.mjs';
+
+test('encodeAppServerMessage writes one newline-delimited JSON object', () => {
+  assert.equal(
+    encodeAppServerMessage({ id: 1, method: 'initialize', params: { ok: true } }),
+    '{"id":1,"method":"initialize","params":{"ok":true}}\n',
+  );
+});
+
+test('parseAppServerLine parses responses, errors, notifications, and server requests', () => {
+  assert.deepEqual(parseAppServerLine('{"id":1,"result":{"ok":true}}'), {
+    kind: 'response',
+    id: 1,
+    result: { ok: true },
+  });
+
+  assert.deepEqual(parseAppServerLine('{"id":"x","error":{"code":-32600,"message":"bad"}}'), {
+    kind: 'error',
+    id: 'x',
+    error: { code: -32600, message: 'bad', data: undefined },
+  });
+
+  assert.deepEqual(parseAppServerLine('{"method":"thread/status/changed","params":{}}'), {
+    kind: 'notification',
+    method: 'thread/status/changed',
+    params: {},
+  });
+
+  assert.deepEqual(parseAppServerLine('{"id":2,"method":"client/request","params":{"a":1}}'), {
+    kind: 'request',
+    id: 2,
+    method: 'client/request',
+    params: { a: 1 },
+  });
+});
+
+test('buildInitializeRequest opts into the experimental app-server API', () => {
+  assert.deepEqual(buildInitializeRequest({ id: 'init-1', version: '1.2.3' }), {
+    id: 'init-1',
+    method: CODEX_APP_SERVER_METHODS.initialize,
+    params: {
+      clientInfo: {
+        name: 'throughline',
+        title: 'Throughline',
+        version: '1.2.3',
+      },
+      capabilities: {
+        experimentalApi: true,
+        optOutNotificationMethods: [],
+      },
+    },
+  });
+
+  assert.deepEqual(buildInitializedNotification(), {
+    method: CODEX_APP_SERVER_METHODS.initialized,
+  });
+});
+
+test('thread request builders encode the verified rollback/inject flow', () => {
+  const threadId = 'thread-1';
+  assert.deepEqual(buildThreadReadRequest({ id: 1, threadId }), {
+    id: 1,
+    method: CODEX_APP_SERVER_METHODS.threadRead,
+    params: { threadId, includeTurns: true },
+  });
+
+  assert.deepEqual(
+    buildThreadResumeRequest({
+      id: 2,
+      threadId,
+      cwd: '/repo',
+      approvalPolicy: 'never',
+      sandbox: 'danger-full-access',
+      model: 'gpt-5.5',
+    }),
+    {
+      id: 2,
+      method: CODEX_APP_SERVER_METHODS.threadResume,
+      params: {
+        threadId,
+        cwd: '/repo',
+        approvalPolicy: 'never',
+        sandbox: 'danger-full-access',
+        model: 'gpt-5.5',
+        excludeTurns: false,
+      },
+    },
+  );
+
+  assert.deepEqual(buildThreadRollbackRequest({ id: 3, threadId, numTurns: 1 }), {
+    id: 3,
+    method: CODEX_APP_SERVER_METHODS.threadRollback,
+    params: { threadId, numTurns: 1 },
+  });
+
+  const item = buildDeveloperMessageItem('active work marker');
+  assert.deepEqual(buildThreadInjectItemsRequest({ id: 4, threadId, items: [item] }), {
+    id: 4,
+    method: CODEX_APP_SERVER_METHODS.threadInjectItems,
+    params: { threadId, items: [item] },
+  });
+});
+
+test('turn and item builders match the app-server shapes observed in the spike', () => {
+  assert.deepEqual(buildTextInputItem('hello'), {
+    type: 'text',
+    text: 'hello',
+    text_elements: [],
+  });
+
+  assert.deepEqual(buildDeveloperMessageItem('remember this'), {
+    type: 'message',
+    role: 'developer',
+    content: [{ type: 'input_text', text: 'remember this' }],
+  });
+
+  assert.deepEqual(buildTurnStartRequest({ id: 1, threadId: 'thread-1', text: 'continue' }), {
+    id: 1,
+    method: CODEX_APP_SERVER_METHODS.turnStart,
+    params: {
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'continue', text_elements: [] }],
+    },
+  });
+});
+
+test('buildThreadRollbackRequest rejects numTurns below the documented minimum', () => {
+  assert.throws(
+    () => buildThreadRollbackRequest({ id: 1, threadId: 'thread-1', numTurns: 0 }),
+    /numTurns must be an integer >= 1/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add a small Codex app-server protocol helper module for newline JSON framing and message parsing.
- Add builders for the verified initialize/read/resume/rollback/inject/turn-start flow.
- Cover the observed app-server message shapes and the documented rollback `numTurns >= 1` guard with unit tests.

## Verification
- npm test (297 pass)
- git diff --check