### PR TITLE
fix: report Codex app-server spawn failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ shipped to npm but were not individually tagged on GitHub.
   experimental guarded execution path behind
   `THROUGHLINE_EXPERIMENTAL_CODEX_TRIM=1`. It sends app-server read/resume,
   rollback, then curated-memory inject, and never starts a model turn.
+- Codex app-server helpers now report spawn failures explicitly instead of
+  waiting for a request timeout.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual

--- a/src/codex-app-server.mjs
+++ b/src/codex-app-server.mjs
@@ -401,6 +401,7 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
   let stdoutBuffer = '';
   let stderr = '';
   let closed = false;
+  let failure = null;
   const pending = new Map();
   const notifications = [];
 
@@ -438,13 +439,17 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
     stderr += chunk.toString('utf8');
   });
 
+  child.on('error', (err) => {
+    failure = err instanceof Error ? err : new Error(String(err));
+    closed = true;
+    clearTimeout(overallTimer);
+    rejectPending(`codex app-server failed to start: ${failure.message}`);
+  });
+
   child.on('exit', (code, signal) => {
     closed = true;
     clearTimeout(overallTimer);
-    for (const [id, pendingRequest] of pending) {
-      pending.delete(id);
-      pendingRequest.reject(new Error(`codex app-server exited before response ${id}: code=${code} signal=${signal}`));
-    }
+    rejectPending(`codex app-server exited before response: code=${code} signal=${signal}`);
   });
 
   return {
@@ -456,7 +461,9 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
       if (!isRequestId(message.id)) {
         throw new Error('app-server request message requires an id');
       }
-      child.stdin.write(encodeAppServerMessage(message));
+      if (failure) {
+        return Promise.reject(new Error(`codex app-server is unavailable: ${failure.message}`));
+      }
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
           if (pending.has(message.id)) {
@@ -475,6 +482,14 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
             }
           },
         });
+        try {
+          child.stdin.write(encodeAppServerMessage(message));
+        } catch (err) {
+          clearTimeout(timer);
+          pending.delete(message.id);
+          const msg = err instanceof Error ? err.message : 'unknown';
+          reject(new Error(`failed to write app-server request ${message.method}: ${msg}`));
+        }
       });
     },
     notify(message) {
@@ -491,6 +506,13 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
       });
     },
   };
+
+  function rejectPending(reason) {
+    for (const [id, pendingRequest] of pending) {
+      pending.delete(id);
+      pendingRequest.reject(new Error(`${reason}; request=${id}`));
+    }
+  }
 }
 
 function countTurns(result) {

--- a/src/codex-app-server.test.mjs
+++ b/src/codex-app-server.test.mjs
@@ -14,6 +14,7 @@ import {
   buildTurnStartRequest,
   encodeAppServerMessage,
   parseAppServerLine,
+  runCodexTrimPreflight,
 } from './codex-app-server.mjs';
 
 test('encodeAppServerMessage writes one newline-delimited JSON object', () => {
@@ -144,5 +145,19 @@ test('buildThreadRollbackRequest rejects numTurns below the documented minimum',
   assert.throws(
     () => buildThreadRollbackRequest({ id: 1, threadId: 'thread-1', numTurns: 0 }),
     /numTurns must be an integer >= 1/,
+  );
+});
+
+test('runCodexTrimPreflight reports app-server spawn failure explicitly', async () => {
+  await assert.rejects(
+    () =>
+      runCodexTrimPreflight({
+        threadId: 'thread-1',
+        cwd: process.cwd(),
+        rollbackTurns: 1,
+        command: `/tmp/throughline-missing-codex-app-server-${process.pid}`,
+        requestTimeoutMs: 1_000,
+      }),
+    /codex app-server failed to start|codex app-server is unavailable/,
   );
 });


### PR DESCRIPTION
## Summary
- Reject pending app-server requests immediately when the Codex app-server process fails to start
- Return explicit unavailable/write errors instead of waiting for request timeouts
- Add coverage for missing app-server command failures

## Verification
- `npm test` (303 pass)
- `git diff --check`