### PR TITLE
fix: sort Codex thread candidates by rollout activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ shipped to npm but were not individually tagged on GitHub.
 - `throughline codex-threads` lists read-only Codex rollout/thread candidates
   for the current project so users can pass an explicit `--codex-thread-id`
   without Throughline guessing the active thread.
+- `throughline codex-threads` now sorts candidates by rollout file mtime, not
+  stale `session_index.jsonl` timestamps, so actively written threads appear
+  before old probe threads.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual

--- a/src/codex-thread-index.mjs
+++ b/src/codex-thread-index.mjs
@@ -32,13 +32,15 @@ export function listCodexThreadCandidates({
       return {
         id: rollout.threadId,
         threadName: indexed.thread_name ?? null,
-        updatedAt: indexed.updated_at ?? meta?.timestamp ?? rollout.mtimeIso,
+        updatedAt: rollout.mtimeIso,
+        indexedUpdatedAt: indexed.updated_at ?? null,
         rolloutStartedAt: rollout.startedAt,
         rolloutPath: rollout.path,
         cwd,
         source: meta?.source ?? null,
         cliVersion: meta?.cli_version ?? null,
         matchesProject,
+        mtimeMs: rollout.mtimeMs,
       };
     })
     .filter((candidate) => allProjects || candidate.matchesProject)
@@ -119,10 +121,8 @@ function readFirstLine(path) {
 }
 
 function compareCandidates(a, b) {
-  const aTime = Date.parse(a.updatedAt ?? a.rolloutStartedAt ?? '');
-  const bTime = Date.parse(b.updatedAt ?? b.rolloutStartedAt ?? '');
-  if (Number.isFinite(aTime) && Number.isFinite(bTime) && aTime !== bTime) {
-    return bTime - aTime;
+  if (a.mtimeMs !== b.mtimeMs) {
+    return b.mtimeMs - a.mtimeMs;
   }
   return String(b.rolloutPath).localeCompare(String(a.rolloutPath));
 }

--- a/src/codex-thread-index.test.mjs
+++ b/src/codex-thread-index.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -63,12 +63,51 @@ test('listCodexThreadCandidates: filters rollouts to current project and merges 
   }
 });
 
+test('listCodexThreadCandidates: sorts by rollout mtime rather than stale index updated_at', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tl-codex-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'tl-codex-project-'));
+  try {
+    writeFileSync(
+      join(home, 'session_index.jsonl'),
+      [
+        '{"id":"019dfaba-f87e-7f41-a144-d5ca7c6dd7f9","thread_name":"Old index newer","updated_at":"2026-05-06T20:00:00Z"}',
+        '{"id":"019dfa40-1cc8-7d13-a110-16b09364fa6a","thread_name":"Current file older index","updated_at":"2026-05-05T20:00:00Z"}',
+        '',
+      ].join('\n'),
+    );
+    const oldPath = writeRollout(home, {
+      day: '06',
+      started: '2026-05-06T09-40-50',
+      id: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+      cwd: project,
+    });
+    const currentPath = writeRollout(home, {
+      day: '06',
+      started: '2026-05-06T07-26-38',
+      id: '019dfa40-1cc8-7d13-a110-16b09364fa6a',
+      cwd: project,
+    });
+    utimesSync(oldPath, new Date('2026-05-06T01:00:00Z'), new Date('2026-05-06T01:00:00Z'));
+    utimesSync(currentPath, new Date('2026-05-06T03:00:00Z'), new Date('2026-05-06T03:00:00Z'));
+
+    const candidates = listCodexThreadCandidates({ codexHome: home, projectPath: project });
+
+    assert.equal(candidates[0].id, '019dfa40-1cc8-7d13-a110-16b09364fa6a');
+    assert.equal(candidates[0].indexedUpdatedAt, '2026-05-05T20:00:00Z');
+    assert.equal(candidates[1].id, '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 function writeRollout(home, { day, started, id, cwd }) {
   const dir = join(home, 'sessions', '2026', '05', day);
   mkdirSync(dir, { recursive: true });
   const fileStarted = started.replace(/:/g, '-');
+  const path = join(dir, `rollout-${fileStarted}-${id}.jsonl`);
   writeFileSync(
-    join(dir, `rollout-${fileStarted}-${id}.jsonl`),
+    path,
     JSON.stringify({
       timestamp: '2026-05-06T00:40:54.808Z',
       type: 'session_meta',
@@ -81,4 +120,5 @@ function writeRollout(home, { day, started, id, cwd }) {
       },
     }) + '\n',
   );
+  return path;
 }


### PR DESCRIPTION
## Summary
- Sort `throughline codex-threads` by rollout file mtime instead of stale session index timestamps
- Expose `indexedUpdatedAt` separately so stale index metadata stays visible without driving order
- Add regression coverage for active rollout files appearing before old probe threads

## Verification
- `npm test` (306 pass)
- `git diff --check`
- `node bin/throughline.mjs codex-threads --json --limit 3`