### PR TITLE
feat: add Codex rollout-backed trim source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ shipped to npm but were not individually tagged on GitHub.
 - Codex app-server protocol helpers for the verified trim flow: newline JSON
   framing, initialize / resume / rollback / inject / turn-start request
   builders, and parser coverage.
+- Codex rollout-backed trim source for explicit `--codex-thread-id` plans.
+  This lets Codex dry-run / preflight / guarded execute use the active rollout
+  even when the Throughline DB has no Codex `bodies` rows.
 
 ### Changed
 - Resume context now frames recent L2 as an active work thread with explicit
@@ -69,6 +72,9 @@ shipped to npm but were not individually tagged on GitHub.
 - `throughline codex-threads` now sorts candidates by rollout file mtime, not
   stale `session_index.jsonl` timestamps, so actively written threads appear
   before old probe threads.
+- Codex trim memory previews now apply `thread_rolled_back` rollout events
+  before building the active work thread, so rolled-back tail turns are not
+  reintroduced as current memory.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual

--- a/README.md
+++ b/README.md
@@ -217,7 +217,11 @@ trimmed, what recent turns would remain, and what curated memory would need to
 be injected back. Codex also has a guarded preflight and experimental execute
 path, but automatic rollback / inject remains disabled. Throughline never
 guesses the active Codex thread: use `throughline codex-threads` to inspect
-read-only rollout candidates, then pass the chosen id explicitly.
+read-only rollout candidates, then pass the chosen id explicitly. When that
+explicit Codex thread has a current-project rollout, `throughline trim` can use
+the rollout as the trim source even if the Throughline DB has no captured Codex
+turn bodies; rollback events in the rollout are applied before the active work
+memory preview is built.
 
 ```bash
 throughline doctor --trim --host claude

--- a/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
+++ b/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
@@ -442,6 +442,8 @@ Phase 8 partial implementation result (2026-05-06):
 - `--execute` は model turn を開始しない。つまり実行直後の「注入内容が次 turn で model-visible か」は Phase 6 の実測 spike で確認済みだが、この CLI path ではユーザー実 thread を mutate する実機 smoke はまだ行っていない。
 - fake app-server テストで、env 無しでは app-server を起動せず拒否すること、preflight は rollback / inject を送らないこと、execute は `read -> resume -> rollback -> inject -> read` の順で curated memory を注入することを固定した。
 - `throughline codex-threads [--json] [--all-projects] [--limit N]` を追加した。これは `~/.codex/session_index.jsonl` と `~/.codex/sessions/**/rollout-*.jsonl` を read-only に読み、現在 project の Codex thread id 候補を表示する。候補を出すだけで、自動 trim の対象 thread として採用しない。
+- `--host codex --codex-thread-id <id>` の計画作成では、明示 thread id と現在 project に一致する rollout JSONL があれば `codex-rollout` を trim source として使う。これにより Throughline DB の `bodies` が 0 件でも、Codex 側の active turns から rollback candidate と memory preview を作れる。
+- `codex-rollout` source は `event_msg:task_started` を turn として扱い、`event_msg:thread_rolled_back` を適用して active turns を再構成する。rollback 済み tail は current memory preview に戻さない。
 - Claude slash command [.claude/commands/tl-trim.md](../.claude/commands/tl-trim.md) を追加し、現行 Claude が current-work memo を書いてから `throughline trim --dry-run --host claude --memo-stdin` を呼ぶ dry-run UX にした。
 - `throughline install` / `uninstall` は `/tl-trim` も配布 / 削除する。
 - `throughline doctor --trim --host claude|codex|unknown` を追加し、default keep-recent、automatic rollback / inject 可否、manual procedure を表示する。
@@ -462,6 +464,7 @@ Current-work framing research note (2026-05-06):
 
 - [ ] 対応 host では同一 session / thread の context trim が動く。
 - [x] Codex では guarded execute path が fake app-server 上で rollback / inject 順序を満たす。
+- [x] Codex では明示 thread id の rollout JSONL から active turns / memory preview を作り、DB 未捕捉の Codex 作業でも dry-run / preflight / guarded execute の plan source にできる。
 - [x] 非対応 host では、何が足りないかを明示して止まる。
 - [x] Claude の既存 `/tl` baton handoff は残る。
 

--- a/src/cli/trim.mjs
+++ b/src/cli/trim.mjs
@@ -1,4 +1,5 @@
 import { runCodexTrimExecution, runCodexTrimPreflight } from '../codex-app-server.mjs';
+import { buildCodexRolloutTrimSource } from '../codex-rollout-memory.mjs';
 import { getDb } from '../db.mjs';
 import {
   DEFAULT_TRIM_KEEP_RECENT,
@@ -100,6 +101,13 @@ export async function run(args) {
 
   const inflightMemo = parsed.memoStdin ? await readStdin() : null;
   const db = getDb();
+  const trimSource =
+    parsed.host === 'codex' && parsed.codexThreadId
+      ? buildCodexRolloutTrimSource({
+          threadId: parsed.codexThreadId,
+          projectPath: process.cwd(),
+        })
+      : null;
   const plan = buildTrimPlan(db, {
     sessionId: parsed.sessionId,
     projectPath: process.cwd(),
@@ -108,6 +116,7 @@ export async function run(args) {
     trimAll: parsed.trimAll,
     inflightMemo,
     codexThreadId: parsed.codexThreadId,
+    trimSource,
   });
 
   if (!parsed.dryRun) {

--- a/src/codex-rollout-memory.mjs
+++ b/src/codex-rollout-memory.mjs
@@ -1,0 +1,224 @@
+import { readFileSync } from 'node:fs';
+
+import { defaultCodexHome, findCodexThreadCandidate } from './codex-thread-index.mjs';
+
+const DEFAULT_PREVIEW_MAX_CHARS = 8_000;
+const MAX_ENTRY_CHARS = 900;
+const MAX_RECENT_ENTRIES = 40;
+
+export function buildCodexRolloutTrimSource({
+  threadId,
+  codexHome = defaultCodexHome(),
+  projectPath = process.cwd(),
+  previewMaxChars = DEFAULT_PREVIEW_MAX_CHARS,
+} = {}) {
+  if (typeof threadId !== 'string' || threadId.length === 0) {
+    throw new Error('threadId is required');
+  }
+
+  const candidate = findCodexThreadCandidate({
+    threadId,
+    codexHome,
+    projectPath,
+    requireProjectMatch: true,
+  });
+  if (!candidate) return null;
+
+  const parsed = parseCodexRolloutFile(candidate.rolloutPath);
+  const memoryPreview = renderCodexRolloutMemoryPreview({
+    candidate,
+    parsed,
+    previewMaxChars,
+  });
+
+  return {
+    source: 'codex-rollout',
+    sourceReason: 'explicit_codex_thread_rollout',
+    threadId,
+    projectPath: candidate.cwd ?? projectPath,
+    capturedTurns: parsed.activeTurnCount,
+    memoryPreview,
+    stats: parsed.stats,
+  };
+}
+
+export function parseCodexRolloutFile(path) {
+  const activeTurns = [];
+  let openTurn = null;
+  let pendingMessages = [];
+  const stats = {
+    parsedRows: 0,
+    corruptRows: 0,
+    taskStarted: 0,
+    taskComplete: 0,
+    rollbackEvents: 0,
+    rolledBackTurns: 0,
+    skippedMessages: 0,
+  };
+
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+      stats.parsedRows++;
+    } catch {
+      stats.corruptRows++;
+      continue;
+    }
+
+    const payload = row?.payload;
+    if (row?.type !== 'event_msg' || !payload?.type) continue;
+
+    if (payload.type === 'task_started') {
+      const turn = {
+        number: stats.taskStarted + 1,
+        messages: pendingMessages,
+      };
+      pendingMessages = [];
+      activeTurns.push(turn);
+      openTurn = turn;
+      stats.taskStarted++;
+      continue;
+    }
+
+    if (payload.type === 'task_complete') {
+      stats.taskComplete++;
+      openTurn = null;
+      continue;
+    }
+
+    if (payload.type === 'thread_rolled_back') {
+      const count = Math.max(0, Number(payload.num_turns) || 0);
+      stats.rollbackEvents++;
+      stats.rolledBackTurns += count;
+      activeTurns.splice(Math.max(0, activeTurns.length - count), count);
+      if (openTurn && !activeTurns.includes(openTurn)) {
+        openTurn = null;
+      }
+      continue;
+    }
+
+    const message = eventPayloadToMemoryMessage(payload, row.timestamp);
+    if (!message) {
+      if (payload.type === 'user_message' || payload.type === 'agent_message') {
+        stats.skippedMessages++;
+      }
+      continue;
+    }
+
+    if (openTurn) {
+      openTurn.messages.push(message);
+    } else {
+      pendingMessages.push(message);
+    }
+  }
+
+  return {
+    activeTurnCount: activeTurns.length,
+    activeTurns,
+    entries: activeTurns.flatMap((turn) =>
+      turn.messages.map((message) => ({
+        ...message,
+        turn: turn.number,
+      })),
+    ),
+    stats,
+  };
+}
+
+function eventPayloadToMemoryMessage(payload, timestamp) {
+  if (payload.type === 'user_message') {
+    const text = normalizeMessageText(payload.message);
+    if (!text || shouldSkipUserMessage(text)) return null;
+    return {
+      time: timestamp ?? null,
+      role: 'user',
+      text,
+    };
+  }
+
+  if (payload.type === 'agent_message') {
+    const text = normalizeMessageText(payload.message);
+    if (!text) return null;
+    return {
+      time: timestamp ?? null,
+      role: 'assistant',
+      text,
+    };
+  }
+
+  return null;
+}
+
+function shouldSkipUserMessage(text) {
+  return text.startsWith('# AGENTS.md instructions') || text.startsWith('<hook_prompt');
+}
+
+function normalizeMessageText(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function renderCodexRolloutMemoryPreview({ candidate, parsed, previewMaxChars }) {
+  const lines = [];
+  lines.push('## Throughline Trim Memory Preview');
+  lines.push('');
+  lines.push('Intent: Continue the active Codex work thread after rollback.');
+  lines.push('');
+  lines.push('### Reading Contract');
+  lines.push(
+    'This preview is current-task context for continuation, not a passive archive. ' +
+      'Entries are oldest-to-newest; later entries may supersede earlier hypotheses.',
+  );
+  lines.push(
+    'The source is the active Codex rollout after applying thread_rolled_back events; ' +
+      'rolled-back tail turns are not included as current work.',
+  );
+  lines.push('');
+  lines.push('### Source');
+  lines.push(`Codex thread: ${candidate.id}`);
+  lines.push(`Project: ${candidate.cwd ?? 'unknown'}`);
+  lines.push(`Rollout: ${candidate.rolloutPath}`);
+  lines.push(`Active turns: ${parsed.activeTurnCount}`);
+
+  const recentEntries = parsed.entries.slice(-MAX_RECENT_ENTRIES);
+  if (recentEntries.length > 0) {
+    lines.push('');
+    lines.push('### Active Work Thread (Codex Rollout)');
+    lines.push('Entries are oldest-to-newest; later entries may supersede earlier hypotheses.');
+    for (const entry of recentEntries) {
+      const time = entry.time ?? 'unknown-time';
+      lines.push(`[${time}] [turn ${entry.turn}] [${entry.role}] ${clipEntry(entry.text)}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('### Continuation Instruction');
+  lines.push(
+    'Use these Codex rollout entries as the active work thread. Continue from the latest actionable state, ' +
+      'and do not resurrect rolled-back turns or obsolete earlier hypotheses.',
+  );
+
+  const fullText = lines.join('\n');
+  const truncated = fullText.length > previewMaxChars;
+  return {
+    text: truncated
+      ? `${fullText.slice(0, previewMaxChars).trimEnd()}\n\n[truncated for dry-run preview]`
+      : fullText,
+    truncated,
+    stats: {
+      source: 'codex-rollout',
+      activeTurns: parsed.activeTurnCount,
+      recentEntries: parsed.entries.length,
+      rollbackEvents: parsed.stats.rollbackEvents,
+      rolledBackTurns: parsed.stats.rolledBackTurns,
+      skippedMessages: parsed.stats.skippedMessages,
+    },
+  };
+}
+
+function clipEntry(text) {
+  if (text.length <= MAX_ENTRY_CHARS) return text;
+  return `${text.slice(0, MAX_ENTRY_CHARS).trimEnd()} [entry truncated]`;
+}

--- a/src/codex-rollout-memory.test.mjs
+++ b/src/codex-rollout-memory.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildCodexRolloutTrimSource, parseCodexRolloutFile } from './codex-rollout-memory.mjs';
+
+test('parseCodexRolloutFile: applies rollback events before rendering active work', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tl-codex-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'tl-codex-project-'));
+  try {
+    const rollout = writeRollout(home, {
+      id: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+      cwd: project,
+      events: [
+        event('user_message', { message: '# AGENTS.md instructions for /repo\nskip me' }),
+        event('user_message', { message: 'start active task' }),
+        event('task_started'),
+        event('agent_message', { message: 'turn one answer' }),
+        event('task_complete'),
+        event('user_message', { message: '<hook_prompt hook_run_id="stop">skip me</hook_prompt>' }),
+        event('user_message', { message: 'continue active task' }),
+        event('task_started'),
+        event('agent_message', { message: 'turn two answer' }),
+        event('task_complete'),
+        event('user_message', { message: 'rolled back request' }),
+        event('task_started'),
+        event('agent_message', { message: 'rolled back answer' }),
+        event('task_complete'),
+        event('thread_rolled_back', { num_turns: 1 }),
+        event('user_message', { message: 'new request after rollback' }),
+        event('task_started'),
+        event('agent_message', { message: 'new answer after rollback' }),
+        event('task_complete'),
+      ],
+    });
+
+    const parsed = parseCodexRolloutFile(rollout);
+
+    assert.equal(parsed.activeTurnCount, 3);
+    assert.equal(parsed.stats.rolledBackTurns, 1);
+    assert.deepEqual(
+      parsed.entries.map((entry) => entry.text),
+      [
+        'start active task',
+        'turn one answer',
+        'continue active task',
+        'turn two answer',
+        'new request after rollback',
+        'new answer after rollback',
+      ],
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('buildCodexRolloutTrimSource: returns trim source for explicit current-project Codex thread', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tl-codex-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'tl-codex-project-'));
+  try {
+    writeRollout(home, {
+      id: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+      cwd: project,
+      events: [
+        event('user_message', { message: 'implement rollout source' }),
+        event('task_started'),
+        event('agent_message', { message: 'rollout source implemented' }),
+        event('task_complete'),
+      ],
+    });
+
+    const source = buildCodexRolloutTrimSource({
+      threadId: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+      codexHome: home,
+      projectPath: project,
+    });
+
+    assert.equal(source.source, 'codex-rollout');
+    assert.equal(source.capturedTurns, 1);
+    assert.equal(source.threadId, '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9');
+    assert.match(source.memoryPreview.text, /Active Work Thread \(Codex Rollout\)/);
+    assert.match(source.memoryPreview.text, /implement rollout source/);
+    assert.match(source.memoryPreview.text, /rolled-back tail turns are not included/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+function writeRollout(home, { id, cwd, events }) {
+  const dir = join(home, 'sessions', '2026', '05', '06');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-05-06T09-40-50-${id}.jsonl`);
+  const rows = [
+    {
+      timestamp: '2026-05-06T00:40:50.000Z',
+      type: 'session_meta',
+      payload: {
+        id,
+        timestamp: '2026-05-06T00:40:50.000Z',
+        cwd,
+        source: 'vscode',
+        cli_version: '0.128.0-alpha.1',
+      },
+    },
+    ...events,
+  ];
+  writeFileSync(path, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
+  return path;
+}
+
+function event(type, payload = {}) {
+  return {
+    timestamp: '2026-05-06T00:40:51.000Z',
+    type: 'event_msg',
+    payload: {
+      type,
+      ...payload,
+    },
+  };
+}

--- a/src/codex-thread-index.mjs
+++ b/src/codex-thread-index.mjs
@@ -49,6 +49,47 @@ export function listCodexThreadCandidates({
   return candidates.slice(0, limit);
 }
 
+export function findCodexThreadCandidate({
+  threadId,
+  codexHome = defaultCodexHome(),
+  projectPath = process.cwd(),
+  requireProjectMatch = true,
+} = {}) {
+  if (typeof threadId !== 'string' || threadId.length === 0) {
+    throw new Error('threadId is required');
+  }
+
+  const index = readSessionIndex(codexHome);
+  const rollouts = findRolloutFiles(join(codexHome, 'sessions'));
+  const normalizedProject = normalizePath(projectPath);
+
+  const matches = rollouts
+    .filter((rollout) => rollout.threadId === threadId)
+    .map((rollout) => {
+      const meta = readSessionMeta(rollout.path);
+      const indexed = index.get(rollout.threadId) ?? {};
+      const cwd = meta?.cwd ?? null;
+      const matchesProject = cwd ? normalizePath(cwd) === normalizedProject : false;
+      return {
+        id: rollout.threadId,
+        threadName: indexed.thread_name ?? null,
+        updatedAt: rollout.mtimeIso,
+        indexedUpdatedAt: indexed.updated_at ?? null,
+        rolloutStartedAt: rollout.startedAt,
+        rolloutPath: rollout.path,
+        cwd,
+        source: meta?.source ?? null,
+        cliVersion: meta?.cli_version ?? null,
+        matchesProject,
+        mtimeMs: rollout.mtimeMs,
+      };
+    })
+    .filter((candidate) => !requireProjectMatch || candidate.matchesProject)
+    .sort(compareCandidates);
+
+  return matches[0] ?? null;
+}
+
 export function readSessionIndex(codexHome = defaultCodexHome()) {
   const path = join(codexHome, 'session_index.jsonl');
   const index = new Map();

--- a/src/codex-thread-index.test.mjs
+++ b/src/codex-thread-index.test.mjs
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { listCodexThreadCandidates, readSessionIndex } from './codex-thread-index.mjs';
+import {
+  findCodexThreadCandidate,
+  listCodexThreadCandidates,
+  readSessionIndex,
+} from './codex-thread-index.mjs';
 
 test('readSessionIndex: reads JSONL rows and ignores corrupt rows', () => {
   const home = mkdtempSync(join(tmpdir(), 'tl-codex-home-'));
@@ -98,6 +102,42 @@ test('listCodexThreadCandidates: sorts by rollout mtime rather than stale index 
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test('findCodexThreadCandidate: requires current project match for explicit thread id', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tl-codex-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'tl-codex-project-'));
+  const otherProject = mkdtempSync(join(tmpdir(), 'tl-codex-other-'));
+  try {
+    writeRollout(home, {
+      day: '06',
+      started: '2026-05-06T09-41-50',
+      id: '019dfabb-1111-7111-8111-111111111111',
+      cwd: otherProject,
+    });
+
+    assert.equal(
+      findCodexThreadCandidate({
+        threadId: '019dfabb-1111-7111-8111-111111111111',
+        codexHome: home,
+        projectPath: project,
+      }),
+      null,
+    );
+
+    const candidate = findCodexThreadCandidate({
+      threadId: '019dfabb-1111-7111-8111-111111111111',
+      codexHome: home,
+      projectPath: project,
+      requireProjectMatch: false,
+    });
+    assert.equal(candidate.id, '019dfabb-1111-7111-8111-111111111111');
+    assert.equal(candidate.cwd, otherProject);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+    rmSync(otherProject, { recursive: true, force: true });
   }
 });
 

--- a/src/trim-cli.test.mjs
+++ b/src/trim-cli.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -101,6 +101,27 @@ async function seedDb(home, project) {
   }
 }
 
+async function seedEmptyDb(home, project) {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    const mod = await import(`./db.mjs?trimCliEmpty=${Date.now()}-${Math.random()}`);
+    const db = mod.getDb();
+    db.prepare(
+      `INSERT INTO sessions (session_id, project_path, status, created_at, updated_at)
+       VALUES ('sess-empty-codex', ?, 'active', 1, 2)`,
+    ).run(project);
+    db.close();
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+  }
+}
+
 function runTrim(home, project, args = [], input = null, extraEnv = {}) {
   return spawnSync(process.execPath, [join(REPO_ROOT, 'bin/throughline.mjs'), 'trim', ...args], {
     cwd: project,
@@ -161,6 +182,48 @@ test('trim CLI carries explicit Codex thread id in dry-run JSON', async () => {
   } finally {
     rmSync(project, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('trim CLI uses explicit Codex rollout source when DB has no captured turns', async () => {
+  const home = makeTempHome();
+  const codexHome = makeTempHome();
+  const project = makeTempProject();
+  try {
+    await seedEmptyDb(home, project);
+    writeCodexRollout(codexHome, {
+      project,
+      threadId: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+      turnCount: 22,
+    });
+
+    const result = runTrim(
+      home,
+      project,
+      [
+        '--dry-run',
+        '--host',
+        'codex',
+        '--codex-thread-id',
+        '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+        '--json',
+      ],
+      null,
+      { CODEX_HOME: codexHome },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const plan = JSON.parse(result.stdout);
+    assert.equal(plan.session.id, 'sess-empty-codex');
+    assert.equal(plan.trim.source, 'codex-rollout');
+    assert.equal(plan.trim.capturedTurns, 22);
+    assert.equal(plan.trim.rollbackTurns, 2);
+    assert.match(plan.memoryPreview.text, /Active Work Thread \(Codex Rollout\)/);
+    assert.match(plan.memoryPreview.text, /codex user turn 22/);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
   }
 });
 
@@ -301,6 +364,56 @@ function assertInOrder(text, needles) {
     assert.notEqual(index, -1, `missing ${needle.trim()} after offset ${offset}`);
     offset = index + needle.length;
   }
+}
+
+function writeCodexRollout(codexHome, { project, threadId, turnCount }) {
+  const dir = join(codexHome, 'sessions', '2026', '05', '06');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-05-06T09-40-50-${threadId}.jsonl`);
+  const rows = [
+    {
+      timestamp: '2026-05-06T00:40:50.000Z',
+      type: 'session_meta',
+      payload: {
+        id: threadId,
+        timestamp: '2026-05-06T00:40:50.000Z',
+        cwd: project,
+        source: 'vscode',
+        cli_version: '0.128.0-alpha.1',
+      },
+    },
+  ];
+
+  for (let turn = 1; turn <= turnCount; turn++) {
+    rows.push({
+      timestamp: `2026-05-06T00:41:${String(turn).padStart(2, '0')}.000Z`,
+      type: 'event_msg',
+      payload: {
+        type: 'user_message',
+        message: `codex user turn ${turn}`,
+      },
+    });
+    rows.push({
+      timestamp: `2026-05-06T00:41:${String(turn).padStart(2, '0')}.100Z`,
+      type: 'event_msg',
+      payload: { type: 'task_started' },
+    });
+    rows.push({
+      timestamp: `2026-05-06T00:41:${String(turn).padStart(2, '0')}.200Z`,
+      type: 'event_msg',
+      payload: {
+        type: 'agent_message',
+        message: `codex assistant turn ${turn}`,
+      },
+    });
+    rows.push({
+      timestamp: `2026-05-06T00:41:${String(turn).padStart(2, '0')}.300Z`,
+      type: 'event_msg',
+      payload: { type: 'task_complete' },
+    });
+  }
+
+  writeFileSync(path, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
 }
 
 test('trim CLI accepts current-work memo on stdin for dry-run preview', async () => {

--- a/src/trim-model.mjs
+++ b/src/trim-model.mjs
@@ -218,12 +218,14 @@ export function buildTrimPlan(
     trimAll = false,
     inflightMemo = null,
     codexThreadId = null,
+    trimSource = null,
     previewMaxChars = 1_500,
   } = {},
 ) {
   const normalizedHost = TRIM_HOSTS.includes(host) ? host : 'unknown';
+  const normalizedTrimSource = normalizeTrimSource(trimSource);
   const resolvedSessionId = sessionId ?? findLatestSessionIdForProject(db, projectPath);
-  if (!resolvedSessionId) {
+  if (!resolvedSessionId && !normalizedTrimSource) {
     return {
       status: 'unavailable',
       reason: 'no_session',
@@ -232,8 +234,8 @@ export function buildTrimPlan(
     };
   }
 
-  const session = loadSession(db, resolvedSessionId);
-  if (!session) {
+  const session = resolvedSessionId ? loadSession(db, resolvedSessionId) : null;
+  if (resolvedSessionId && !session && !normalizedTrimSource) {
     return {
       status: 'unavailable',
       reason: 'session_not_found',
@@ -245,34 +247,39 @@ export function buildTrimPlan(
   const effectiveKeepRecent = trimAll ? 0 : keepRecent;
   assertKeepRecent(effectiveKeepRecent);
 
-  const capturedTurns = countDistinctCapturedTurns(db, resolvedSessionId);
+  const capturedTurns =
+    normalizedTrimSource?.capturedTurns ?? countDistinctCapturedTurns(db, resolvedSessionId);
   const rollbackTurns = Math.max(0, capturedTurns - effectiveKeepRecent);
   const keepTurns = capturedTurns - rollbackTurns;
-  const record = buildHandoffRecord(db, {
-    sessionId: resolvedSessionId,
-    isInheritance: false,
-    inflightMemo,
-    recentTurnLimit: DEFAULT_TRIM_KEEP_RECENT,
-  });
-  const memoryPreview = collectMemoryPreview(record, previewMaxChars);
+  const record = normalizedTrimSource
+    ? null
+    : buildHandoffRecord(db, {
+        sessionId: resolvedSessionId,
+        isInheritance: false,
+        inflightMemo,
+        recentTurnLimit: DEFAULT_TRIM_KEEP_RECENT,
+      });
+  const memoryPreview = normalizedTrimSource?.memoryPreview ?? collectMemoryPreview(record, previewMaxChars);
   const hostInfo = describeTrimHost(normalizedHost);
 
   return {
     status: rollbackTurns === 0 ? 'noop' : hostInfo.status,
     reason: rollbackTurns === 0 ? 'nothing_to_trim' : hostInfo.reason,
     mode: 'dry-run',
-    session: {
-      id: resolvedSessionId,
-      projectPath: session.project_path,
-      status: session.status,
-      mergedInto: session.merged_into ?? null,
-    },
+    session: buildPlanSession({
+      resolvedSessionId,
+      session,
+      trimSource: normalizedTrimSource,
+      projectPath,
+    }),
     host: hostInfo,
     hostIdentity: buildHostIdentity({
       host: normalizedHost,
       codexThreadId,
     }),
     trim: {
+      source: normalizedTrimSource?.source ?? 'throughline-db',
+      sourceReason: normalizedTrimSource?.sourceReason ?? 'throughline_db_session',
       capturedTurns,
       keepRecent: effectiveKeepRecent,
       keepTurns,
@@ -305,6 +312,9 @@ export function renderTrimDryRunReport(plan) {
   if (plan.hostIdentity?.codexThreadId) {
     lines.push(`Codex thread: ${plan.hostIdentity.codexThreadId}`);
   }
+  if (plan.trim.source) {
+    lines.push(`Trim source: ${plan.trim.source}`);
+  }
   lines.push(`Captured turns: ${plan.trim.capturedTurns}`);
   lines.push(`Keep recent turns: ${plan.trim.keepRecent}`);
   lines.push(`Rollback candidate turns: ${plan.trim.rollbackTurns}`);
@@ -328,6 +338,42 @@ export function renderTrimDryRunReport(plan) {
   lines.push(plan.memoryPreview.text);
 
   return lines.join('\n');
+}
+
+function normalizeTrimSource(trimSource) {
+  if (!trimSource) return null;
+  if (!Number.isInteger(trimSource.capturedTurns) || trimSource.capturedTurns < 0) {
+    throw new Error('trimSource.capturedTurns must be a non-negative integer');
+  }
+  if (!trimSource.memoryPreview || typeof trimSource.memoryPreview.text !== 'string') {
+    throw new Error('trimSource.memoryPreview.text is required');
+  }
+
+  return {
+    ...trimSource,
+    source: trimSource.source ?? 'external',
+    sourceReason: trimSource.sourceReason ?? 'external_trim_source',
+  };
+}
+
+function buildPlanSession({ resolvedSessionId, session, trimSource, projectPath }) {
+  if (session) {
+    return {
+      id: resolvedSessionId,
+      projectPath: session.project_path,
+      status: session.status,
+      mergedInto: session.merged_into ?? null,
+      source: 'throughline-db',
+    };
+  }
+
+  return {
+    id: trimSource?.threadId ?? resolvedSessionId ?? null,
+    projectPath: trimSource?.projectPath ?? projectPath ?? null,
+    status: 'external',
+    mergedInto: null,
+    source: trimSource?.source ?? 'external',
+  };
 }
 
 function buildHostIdentity({ host, codexThreadId }) {

--- a/src/trim-model.test.mjs
+++ b/src/trim-model.test.mjs
@@ -158,6 +158,67 @@ test('buildTrimPlan: current-work memo is placed in curated memory preview', () 
   assert.match(plan.memoryPreview.text, /keep implementing trim dry-run/);
 });
 
+test('buildTrimPlan: external Codex rollout source can drive trim without captured DB turns', () => {
+  const db = makeDb();
+  db.prepare(
+    `INSERT INTO sessions (session_id, project_path, status, created_at, updated_at)
+     VALUES ('sess-empty', '/repo', 'active', 1, 2)`,
+  ).run();
+
+  const plan = buildTrimPlan(db, {
+    sessionId: 'sess-empty',
+    host: 'codex',
+    codexThreadId: '019dfabf-thread',
+    keepRecent: 20,
+    trimSource: {
+      source: 'codex-rollout',
+      sourceReason: 'explicit_codex_thread_rollout',
+      threadId: '019dfabf-thread',
+      projectPath: '/repo',
+      capturedTurns: 22,
+      memoryPreview: {
+        text: '## Throughline Trim Memory Preview\n\n### Active Work Thread (Codex Rollout)\nactive',
+        truncated: false,
+        stats: { source: 'codex-rollout' },
+      },
+    },
+  });
+
+  assert.equal(plan.status, 'verified-host-primitive');
+  assert.equal(plan.trim.source, 'codex-rollout');
+  assert.equal(plan.trim.sourceReason, 'explicit_codex_thread_rollout');
+  assert.equal(plan.trim.capturedTurns, 22);
+  assert.equal(plan.trim.rollbackTurns, 2);
+  assert.match(plan.memoryPreview.text, /Codex Rollout/);
+});
+
+test('buildTrimPlan: external Codex rollout source can stand in when DB session is absent', () => {
+  const db = makeDb();
+
+  const plan = buildTrimPlan(db, {
+    host: 'codex',
+    codexThreadId: '019dfabf-thread',
+    keepRecent: 1,
+    trimSource: {
+      source: 'codex-rollout',
+      threadId: '019dfabf-thread',
+      projectPath: '/repo',
+      capturedTurns: 3,
+      memoryPreview: {
+        text: 'active rollout memory',
+        truncated: false,
+        stats: { source: 'codex-rollout' },
+      },
+    },
+  });
+
+  assert.equal(plan.status, 'verified-host-primitive');
+  assert.equal(plan.session.id, '019dfabf-thread');
+  assert.equal(plan.session.status, 'external');
+  assert.equal(plan.session.source, 'codex-rollout');
+  assert.equal(plan.trim.rollbackTurns, 2);
+});
+
 test('renderTrimDryRunReport: explains host boundary and curated memory', () => {
   const db = makeDb();
   seedTurns(db, { count: 2 });


### PR DESCRIPTION
## Summary
- add a Codex rollout parser that reconstructs active turns after thread_rolled_back events
- let explicit --host codex --codex-thread-id <id> trim plans use codex-rollout when DB bodies are absent
- document the rollout-backed trim source and add CLI/model/parser coverage

## Verification
- npm test
- git diff --check
- read-only current thread check: trimSource=codex-rollout, capturedTurns=20, rollbackTurns=0, rolledBackTurns=10

Claude remains primary; this does not modify Claude hooks, slash commands, transcript behavior, or user .claude/settings.json.