### PR TITLE
feat: check Codex trim turn counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ shipped to npm but were not individually tagged on GitHub.
   the Claude/Throughline `session_id`, avoiding latest-rollout guessing.
 - `throughline trim --preflight --host codex --codex-thread-id <id>` now
   performs a guarded Codex app-server initialize/read/resume check and stops
-  before sending rollback or inject.
+  before sending rollback or inject. When the plan source is `codex-rollout`,
+  preflight compares rollout active turns with app-server read/resume turns and
+  refuses the plan if they differ.
 - `throughline trim --execute --host codex --codex-thread-id <id>` now has an
   experimental guarded execution path behind
   `THROUGHLINE_EXPERIMENTAL_CODEX_TRIM=1`. It sends app-server read/resume,
@@ -75,6 +77,9 @@ shipped to npm but were not individually tagged on GitHub.
 - Codex trim memory previews now apply `thread_rolled_back` rollout events
   before building the active work thread, so rolled-back tail turns are not
   reintroduced as current memory.
+- Guarded Codex execute now performs the same rollout/app-server turn-count
+  check before rollback; mismatch or unavailable app-server counts refuse
+  execution before any rollback or inject request is sent.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ read-only rollout candidates, then pass the chosen id explicitly. When that
 explicit Codex thread has a current-project rollout, `throughline trim` can use
 the rollout as the trim source even if the Throughline DB has no captured Codex
 turn bodies; rollback events in the rollout are applied before the active work
-memory preview is built.
+memory preview is built. During Codex preflight / guarded execute, Throughline
+also compares the rollout active-turn count with app-server `thread/read` /
+`thread/resume` counts and refuses to mutate the thread if they differ.
 
 ```bash
 throughline doctor --trim --host claude

--- a/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
+++ b/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
@@ -436,8 +436,10 @@ Phase 8 partial implementation result (2026-05-06):
 - `src/codex-app-server.mjs` を追加し、newline JSON framing、initialize / read / resume / rollback / inject / turn-start request builder、server line parser をテストで固定した。これは実行統合の足場であり、まだ non-dry-run trim を有効化しない。
 - shell 環境には現在 Codex thread id が安定して出ていないため、当面は `--codex-thread-id` の明示入力だけを信頼する。最新 rollout 推測による automatic trim は行わない。
 - `throughline trim --preflight --host codex --codex-thread-id <id> [--json]` を追加した。これは `thread/read` と `thread/resume` が対象 thread に届くことを確認し、`rollbackRequestPreview` を返すが、`thread/rollback` / `thread/inject_items` は送らない。
+- `codex-rollout` source の場合、preflight は rollout 側 active turn count と app-server `thread/read` / `thread/resume` の turn count を突き合わせる。不一致または app-server count 不明なら `preflight-refused` として止まり、rollback / inject は送らない。
 - 同日、検証 thread `019dfaba-f87e-7f41-a144-d5ca7c6dd7f9` に実 app-server preflight を当て、`readTurns: 1` / `resumedTurns: 1` / `rollbackSent: false` / `injectSent: false` を確認した。
 - `throughline trim --execute --host codex --codex-thread-id <id> [--json]` を追加した。これは `THROUGHLINE_EXPERIMENTAL_CODEX_TRIM=1` がある場合だけ、app-server の `thread/read`、`thread/resume`、`thread/rollback`、`thread/inject_items`、確認用 `thread/read` を順に送る。
+- `codex-rollout` source の guarded execute は rollback 前に同じ turn count check を実行する。不一致または app-server count 不明なら `execute-refused` として止まり、`thread/rollback` / `thread/inject_items` は送らない。
 - `--execute` が注入する item は `role: "developer"` の raw Responses message item で、中身は `memoryPreview.text`。`memoryPreview.text` は Reading Contract、Active Work Thread、Continuation Instruction を含むため、L2 を単なる過去ログではなく現在タスクの作業文脈として読む前提を維持する。
 - `--execute` は model turn を開始しない。つまり実行直後の「注入内容が次 turn で model-visible か」は Phase 6 の実測 spike で確認済みだが、この CLI path ではユーザー実 thread を mutate する実機 smoke はまだ行っていない。
 - fake app-server テストで、env 無しでは app-server を起動せず拒否すること、preflight は rollback / inject を送らないこと、execute は `read -> resume -> rollback -> inject -> read` の順で curated memory を注入することを固定した。
@@ -465,6 +467,7 @@ Current-work framing research note (2026-05-06):
 - [ ] 対応 host では同一 session / thread の context trim が動く。
 - [x] Codex では guarded execute path が fake app-server 上で rollback / inject 順序を満たす。
 - [x] Codex では明示 thread id の rollout JSONL から active turns / memory preview を作り、DB 未捕捉の Codex 作業でも dry-run / preflight / guarded execute の plan source にできる。
+- [x] Codex では `codex-rollout` active turn count と app-server read/resume turn count を突き合わせ、差分がある場合は mutation 前に拒否する。
 - [x] 非対応 host では、何が足りないかを明示して止まる。
 - [x] Claude の既存 `/tl` baton handoff は残る。
 

--- a/src/cli/trim.mjs
+++ b/src/cli/trim.mjs
@@ -177,8 +177,18 @@ async function runExecute(parsed, plan) {
     cwd: process.cwd(),
     rollbackTurns: plan.trim.rollbackTurns,
     memoryText: plan.memoryPreview.text,
+    expectedTurns: expectedCodexAppServerTurns(plan),
     command,
   });
+
+  if (execution.status === 'refused') {
+    return {
+      status: 'execute-refused',
+      reason: execution.reason,
+      plan,
+      execution,
+    };
+  }
 
   return {
     status: 'executed',
@@ -200,8 +210,18 @@ async function runPreflight(parsed, plan) {
     threadId: parsed.codexThreadId,
     cwd: process.cwd(),
     rollbackTurns: plan.trim.rollbackTurns,
+    expectedTurns: expectedCodexAppServerTurns(plan),
     command,
   });
+  const turnCountStatus = preflight.turnCountCheck?.status;
+  if (turnCountStatus === 'mismatch' || turnCountStatus === 'unknown') {
+    return {
+      status: 'preflight-refused',
+      reason: preflight.turnCountCheck.reason,
+      plan,
+      preflight,
+    };
+  }
 
   return {
     status: 'preflight-ready',
@@ -251,6 +271,10 @@ function hasInjectableMemory(text) {
   return typeof text === 'string' && text.trim().length > 0 && text !== '(no captured memory available)';
 }
 
+function expectedCodexAppServerTurns(plan) {
+  return plan?.trim?.source === 'codex-rollout' ? plan.trim.capturedTurns : null;
+}
+
 function renderTrimActionReport(result) {
   const lines = [];
   lines.push(result.status === 'executed' ? '## Throughline Trim Execute' : '## Throughline Trim Preflight');
@@ -264,6 +288,10 @@ function renderTrimActionReport(result) {
     lines.push(`Codex thread: ${result.preflight.threadId}`);
     lines.push(`Read turns: ${result.preflight.readTurns ?? 'unknown'}`);
     lines.push(`Resumed turns: ${result.preflight.resumedTurns ?? 'unknown'}`);
+    if (result.preflight.turnCountCheck) {
+      lines.push(`Turn count check: ${result.preflight.turnCountCheck.status}`);
+      lines.push(`Expected turns: ${result.preflight.turnCountCheck.expectedTurns ?? 'unchecked'}`);
+    }
     lines.push(`Rollback sent: ${result.preflight.rollbackSent ? 'yes' : 'no'}`);
     lines.push(`Inject sent: ${result.preflight.injectSent ? 'yes' : 'no'}`);
     lines.push(`Rollback candidate turns: ${result.plan.trim.rollbackTurns}`);
@@ -274,6 +302,10 @@ function renderTrimActionReport(result) {
     lines.push(`Codex thread: ${result.execution.threadId}`);
     lines.push(`Read turns: ${result.execution.readTurns ?? 'unknown'}`);
     lines.push(`Resumed turns: ${result.execution.resumedTurns ?? 'unknown'}`);
+    if (result.execution.turnCountCheck) {
+      lines.push(`Turn count check: ${result.execution.turnCountCheck.status}`);
+      lines.push(`Expected turns: ${result.execution.turnCountCheck.expectedTurns ?? 'unchecked'}`);
+    }
     lines.push(`Rollback sent: ${result.execution.rollbackSent ? 'yes' : 'no'}`);
     lines.push(`Inject sent: ${result.execution.injectSent ? 'yes' : 'no'}`);
     lines.push(`Injected items: ${result.execution.injectedItems}`);

--- a/src/codex-app-server.mjs
+++ b/src/codex-app-server.mjs
@@ -228,6 +228,7 @@ export async function runCodexTrimPreflight({
   threadId,
   cwd,
   rollbackTurns,
+  expectedTurns = null,
   command = 'codex',
   commandArgs = ['app-server', '--listen', 'stdio://'],
   timeoutMs = 30_000,
@@ -239,6 +240,7 @@ export async function runCodexTrimPreflight({
   if (!Number.isInteger(rollbackTurns) || rollbackTurns < 1) {
     throw new Error('runCodexTrimPreflight: rollbackTurns must be an integer >= 1');
   }
+  assertOptionalTurnCount(expectedTurns, 'runCodexTrimPreflight: expectedTurns');
   if (!Array.isArray(commandArgs)) {
     throw new Error('runCodexTrimPreflight: commandArgs must be an array');
   }
@@ -276,14 +278,21 @@ export async function runCodexTrimPreflight({
         excludeTurns: false,
       }),
     );
+    const readTurns = countTurns(beforeRead);
+    const resumedTurns = countTurns(resumed);
 
     return {
       status: 'preflight-ready',
       threadId,
       rollbackSent: false,
       injectSent: false,
-      readTurns: countTurns(beforeRead),
-      resumedTurns: countTurns(resumed),
+      readTurns,
+      resumedTurns,
+      turnCountCheck: compareTurnCounts({
+        expectedTurns,
+        readTurns,
+        resumedTurns,
+      }),
       rollbackRequestPreview: buildThreadRollbackRequest({
         id: 'rollback-preview',
         threadId,
@@ -302,6 +311,7 @@ export async function runCodexTrimExecution({
   cwd,
   rollbackTurns,
   memoryText,
+  expectedTurns = null,
   command = 'codex',
   commandArgs = ['app-server', '--listen', 'stdio://'],
   timeoutMs = 30_000,
@@ -314,6 +324,7 @@ export async function runCodexTrimExecution({
   if (!Number.isInteger(rollbackTurns) || rollbackTurns < 1) {
     throw new Error('runCodexTrimExecution: rollbackTurns must be an integer >= 1');
   }
+  assertOptionalTurnCount(expectedTurns, 'runCodexTrimExecution: expectedTurns');
   if (!Array.isArray(commandArgs)) {
     throw new Error('runCodexTrimExecution: commandArgs must be an array');
   }
@@ -351,6 +362,29 @@ export async function runCodexTrimExecution({
         excludeTurns: false,
       }),
     );
+    const readTurns = countTurns(beforeRead);
+    const resumedTurns = countTurns(resumed);
+    const turnCountCheck = compareTurnCounts({
+      expectedTurns,
+      readTurns,
+      resumedTurns,
+    });
+    if (turnCountCheck.status === 'mismatch' || turnCountCheck.status === 'unknown') {
+      return {
+        status: 'refused',
+        reason: 'codex_rollout_app_server_turn_mismatch',
+        threadId,
+        rollbackSent: false,
+        injectSent: false,
+        injectedItems: 0,
+        readTurns,
+        resumedTurns,
+        rollbackRequestedTurns: rollbackTurns,
+        turnCountCheck,
+        notifications: [...new Set(client.notifications)],
+        stderr: client.stderr,
+      };
+    }
     const rollback = await client.request(
       buildThreadRollbackRequest({
         id: randomUUID(),
@@ -379,12 +413,13 @@ export async function runCodexTrimExecution({
       rollbackSent: true,
       injectSent: true,
       injectedItems: 1,
-      readTurns: countTurns(beforeRead),
-      resumedTurns: countTurns(resumed),
+      readTurns,
+      resumedTurns,
       rollbackRequestedTurns: rollbackTurns,
       rollbackResultTurns: countTurns(rollback),
       injectResultTurns: countTurns(inject),
       afterTurns: countTurns(afterRead),
+      turnCountCheck,
       notifications: [...new Set(client.notifications)],
       stderr: client.stderr,
     };
@@ -520,6 +555,40 @@ function countTurns(result) {
   return isRecord(thread) && Array.isArray(thread.turns) ? thread.turns.length : null;
 }
 
+export function compareTurnCounts({ expectedTurns = null, readTurns = null, resumedTurns = null } = {}) {
+  assertOptionalTurnCount(expectedTurns, 'compareTurnCounts: expectedTurns');
+  const counts = { expectedTurns, readTurns, resumedTurns };
+  if (expectedTurns === null || expectedTurns === undefined) {
+    return {
+      status: 'unchecked',
+      reason: 'expected_turns_not_available',
+      ...counts,
+    };
+  }
+
+  if (!Number.isInteger(readTurns) || !Number.isInteger(resumedTurns)) {
+    return {
+      status: 'unknown',
+      reason: 'app_server_turn_count_unavailable',
+      ...counts,
+    };
+  }
+
+  if (readTurns === expectedTurns && resumedTurns === expectedTurns) {
+    return {
+      status: 'match',
+      reason: 'rollout_and_app_server_turn_counts_match',
+      ...counts,
+    };
+  }
+
+  return {
+    status: 'mismatch',
+    reason: 'rollout_and_app_server_turn_counts_differ',
+    ...counts,
+  };
+}
+
 function compactNullish(value) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== null && entry !== undefined),
@@ -535,6 +604,13 @@ function assertRequestId(id, caller) {
 function assertNonEmptyString(value, label) {
   if (typeof value !== 'string' || value.length === 0) {
     throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function assertOptionalTurnCount(value, label) {
+  if (value === null || value === undefined) return;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer when provided`);
   }
 }
 

--- a/src/codex-app-server.test.mjs
+++ b/src/codex-app-server.test.mjs
@@ -12,6 +12,7 @@ import {
   buildThreadResumeRequest,
   buildThreadRollbackRequest,
   buildTurnStartRequest,
+  compareTurnCounts,
   encodeAppServerMessage,
   parseAppServerLine,
   runCodexTrimPreflight,
@@ -145,6 +146,46 @@ test('buildThreadRollbackRequest rejects numTurns below the documented minimum',
   assert.throws(
     () => buildThreadRollbackRequest({ id: 1, threadId: 'thread-1', numTurns: 0 }),
     /numTurns must be an integer >= 1/,
+  );
+});
+
+test('compareTurnCounts: reports match, mismatch, unchecked, and unknown states', () => {
+  assert.deepEqual(
+    compareTurnCounts({
+      expectedTurns: 2,
+      readTurns: 2,
+      resumedTurns: 2,
+    }),
+    {
+      status: 'match',
+      reason: 'rollout_and_app_server_turn_counts_match',
+      expectedTurns: 2,
+      readTurns: 2,
+      resumedTurns: 2,
+    },
+  );
+
+  assert.equal(
+    compareTurnCounts({
+      expectedTurns: 3,
+      readTurns: 2,
+      resumedTurns: 2,
+    }).status,
+    'mismatch',
+  );
+  assert.equal(compareTurnCounts({ readTurns: 2, resumedTurns: 2 }).status, 'unchecked');
+  assert.equal(compareTurnCounts({ expectedTurns: 2, readTurns: null, resumedTurns: 2 }).status, 'unknown');
+});
+
+test('compareTurnCounts: rejects invalid expected turn count', () => {
+  assert.throws(
+    () =>
+      compareTurnCounts({
+        expectedTurns: -1,
+        readTurns: 2,
+        resumedTurns: 2,
+      }),
+    /expectedTurns must be a non-negative integer/,
   );
 });
 

--- a/src/codex-rollout-memory.mjs
+++ b/src/codex-rollout-memory.mjs
@@ -53,6 +53,7 @@ export function parseCodexRolloutFile(path) {
     taskComplete: 0,
     rollbackEvents: 0,
     rolledBackTurns: 0,
+    injectedDeveloperMessages: 0,
     skippedMessages: 0,
   };
 
@@ -68,6 +69,18 @@ export function parseCodexRolloutFile(path) {
     }
 
     const payload = row?.payload;
+    if (row?.type === 'response_item') {
+      const injectedMessage = responseItemToMemoryMessage(payload, row.timestamp);
+      if (injectedMessage) {
+        activeTurns.push({
+          number: `injected-${stats.injectedDeveloperMessages + 1}`,
+          messages: [injectedMessage],
+        });
+        stats.injectedDeveloperMessages++;
+      }
+      continue;
+    }
+
     if (row?.type !== 'event_msg' || !payload?.type) continue;
 
     if (payload.type === 'task_started') {
@@ -151,6 +164,31 @@ function eventPayloadToMemoryMessage(payload, timestamp) {
   return null;
 }
 
+function responseItemToMemoryMessage(payload, timestamp) {
+  if (payload?.type !== 'message' || payload.role !== 'developer') return null;
+  const text = normalizeMessageText(messageContentToText(payload.content));
+  if (!text.startsWith('## Throughline Trim Memory Preview')) return null;
+  if (!text) return null;
+  return {
+    time: timestamp ?? null,
+    role: 'developer',
+    text,
+  };
+}
+
+function messageContentToText(content) {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((item) => {
+      if (typeof item?.text === 'string') return item.text;
+      if (typeof item?.input_text === 'string') return item.input_text;
+      if (typeof item?.output_text === 'string') return item.output_text;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
 function shouldSkipUserMessage(text) {
   return text.startsWith('# AGENTS.md instructions') || text.startsWith('<hook_prompt');
 }
@@ -213,6 +251,7 @@ function renderCodexRolloutMemoryPreview({ candidate, parsed, previewMaxChars })
       recentEntries: parsed.entries.length,
       rollbackEvents: parsed.stats.rollbackEvents,
       rolledBackTurns: parsed.stats.rolledBackTurns,
+      injectedDeveloperMessages: parsed.stats.injectedDeveloperMessages,
       skippedMessages: parsed.stats.skippedMessages,
     },
   };

--- a/src/codex-rollout-memory.test.mjs
+++ b/src/codex-rollout-memory.test.mjs
@@ -29,6 +29,21 @@ test('parseCodexRolloutFile: applies rollback events before rendering active wor
         event('agent_message', { message: 'rolled back answer' }),
         event('task_complete'),
         event('thread_rolled_back', { num_turns: 1 }),
+        responseItem({
+          type: 'message',
+          role: 'developer',
+          content: [
+            {
+              type: 'input_text',
+              text: '## Throughline Trim Memory Preview\n\ninjected trim memory',
+            },
+          ],
+        }),
+        responseItem({
+          type: 'message',
+          role: 'developer',
+          content: [{ type: 'input_text', text: '[caveat] unrelated developer notice' }],
+        }),
         event('user_message', { message: 'new request after rollback' }),
         event('task_started'),
         event('agent_message', { message: 'new answer after rollback' }),
@@ -38,8 +53,9 @@ test('parseCodexRolloutFile: applies rollback events before rendering active wor
 
     const parsed = parseCodexRolloutFile(rollout);
 
-    assert.equal(parsed.activeTurnCount, 3);
+    assert.equal(parsed.activeTurnCount, 4);
     assert.equal(parsed.stats.rolledBackTurns, 1);
+    assert.equal(parsed.stats.injectedDeveloperMessages, 1);
     assert.deepEqual(
       parsed.entries.map((entry) => entry.text),
       [
@@ -47,6 +63,7 @@ test('parseCodexRolloutFile: applies rollback events before rendering active wor
         'turn one answer',
         'continue active task',
         'turn two answer',
+        '## Throughline Trim Memory Preview injected trim memory',
         'new request after rollback',
         'new answer after rollback',
       ],
@@ -120,5 +137,13 @@ function event(type, payload = {}) {
       type,
       ...payload,
     },
+  };
+}
+
+function responseItem(payload) {
+  return {
+    timestamp: '2026-05-06T00:40:51.500Z',
+    type: 'response_item',
+    payload,
   };
 }

--- a/src/trim-cli.test.mjs
+++ b/src/trim-cli.test.mjs
@@ -16,7 +16,14 @@ function makeTempProject() {
   return mkdtempSync(join(tmpdir(), 'tl-trim-project-'));
 }
 
-function makeFakeCodexAppServer(dir, { allowMutation = false } = {}) {
+function makeFakeCodexAppServer(
+  dir,
+  {
+    allowMutation = false,
+    threadId = '019dfabf-thread',
+    turnCount = 2,
+  } = {},
+) {
   const script = join(dir, 'fake-codex-app-server.mjs');
   const log = join(dir, 'fake-codex-app-server.log');
   writeFileSync(
@@ -27,8 +34,8 @@ import { createInterface } from 'node:readline';
 
 const log = ${JSON.stringify(log)};
 const allowMutation = ${JSON.stringify(allowMutation)};
-const threadId = '019dfabf-thread';
-let turns = [{ id: 'turn-1' }, { id: 'turn-2' }];
+const threadId = ${JSON.stringify(threadId)};
+let turns = Array.from({ length: ${JSON.stringify(turnCount)} }, (_, index) => ({ id: 'turn-' + (index + 1) }));
 const rl = createInterface({ input: process.stdin });
 
 function send(message) {
@@ -305,6 +312,112 @@ test('trim CLI preflight reads and resumes Codex thread without rollback or inje
   } finally {
     rmSync(project, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('trim CLI preflight checks Codex rollout source against app-server turns', async () => {
+  const home = makeTempHome();
+  const codexHome = makeTempHome();
+  const project = makeTempProject();
+  const threadId = '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9';
+  try {
+    await seedEmptyDb(home, project);
+    writeCodexRollout(codexHome, {
+      project,
+      threadId,
+      turnCount: 22,
+    });
+    const { script } = makeFakeCodexAppServer(project, { threadId, turnCount: 22 });
+    const result = runTrim(
+      home,
+      project,
+      [
+        '--host',
+        'codex',
+        '--codex-thread-id',
+        threadId,
+        '--preflight',
+        '--codex-app-server-bin',
+        script,
+        '--json',
+      ],
+      null,
+      { CODEX_HOME: codexHome },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.status, 'preflight-ready');
+    assert.deepEqual(payload.preflight.turnCountCheck, {
+      status: 'match',
+      reason: 'rollout_and_app_server_turn_counts_match',
+      expectedTurns: 22,
+      readTurns: 22,
+      resumedTurns: 22,
+    });
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test('trim CLI execute refuses before rollback when rollout and app-server turn counts differ', async () => {
+  const home = makeTempHome();
+  const codexHome = makeTempHome();
+  const project = makeTempProject();
+  const threadId = '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9';
+  try {
+    await seedEmptyDb(home, project);
+    writeCodexRollout(codexHome, {
+      project,
+      threadId,
+      turnCount: 22,
+    });
+    const { script, log } = makeFakeCodexAppServer(project, {
+      allowMutation: true,
+      threadId,
+      turnCount: 21,
+    });
+    const result = runTrim(
+      home,
+      project,
+      [
+        '--host',
+        'codex',
+        '--codex-thread-id',
+        threadId,
+        '--keep-recent',
+        '20',
+        '--execute',
+        '--codex-app-server-bin',
+        script,
+        '--json',
+      ],
+      null,
+      {
+        CODEX_HOME: codexHome,
+        THROUGHLINE_EXPERIMENTAL_CODEX_TRIM: '1',
+      },
+    );
+
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.status, 'execute-refused');
+    assert.equal(payload.reason, 'codex_rollout_app_server_turn_mismatch');
+    assert.equal(payload.execution.rollbackSent, false);
+    assert.equal(payload.execution.injectSent, false);
+    assert.equal(payload.execution.turnCountCheck.status, 'mismatch');
+
+    const calledMethods = readFileSync(log, 'utf8');
+    assert.match(calledMethods, /thread\/read/);
+    assert.match(calledMethods, /thread\/resume/);
+    assert.doesNotMatch(calledMethods, /thread\/rollback/);
+    assert.doesNotMatch(calledMethods, /thread\/inject_items/);
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- compare Codex rollout active-turn count with app-server read/resume counts during preflight
- refuse guarded execute before rollback/inject when rollout/app-server turn counts differ
- count only Throughline trim injected developer memory items from rollout response_item records

## Verification
- npm test
- git diff --check
- read-only current thread preflight: expected/read/resumed turns all 22, turnCountCheck=match

Claude remains primary; this does not modify Claude hooks, slash commands, transcript behavior, or user .claude/settings.json.