### PR TITLE
fix: summarize Codex app-server stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ shipped to npm but were not individually tagged on GitHub.
 - Guarded Codex execute now performs the same rollout/app-server turn-count
   check before rollback; mismatch or unavailable app-server counts refuse
   execution before any rollback or inject request is sent.
+- Codex app-server stderr in trim preflight / guarded execute now compacts
+  repeated unknown-turn item warnings while preserving the first occurrence and
+  unrelated diagnostics.
 
 ### Documentation
 - Added integrated implementation/TODO plan and cross-links for the Codex dual

--- a/src/codex-app-server.mjs
+++ b/src/codex-app-server.mjs
@@ -490,7 +490,7 @@ function startAppServerClient({ command, args, cwd, timeoutMs, requestTimeoutMs 
   return {
     notifications,
     get stderr() {
-      return stderr;
+      return summarizeAppServerStderr(stderr);
     },
     request(message) {
       if (!isRequestId(message.id)) {
@@ -587,6 +587,45 @@ export function compareTurnCounts({ expectedTurns = null, readTurns = null, resu
     reason: 'rollout_and_app_server_turn_counts_differ',
     ...counts,
   };
+}
+
+export function summarizeAppServerStderr(stderr) {
+  if (typeof stderr !== 'string' || stderr.length === 0) return '';
+
+  const lines = stderr.split('\n');
+  const out = [];
+  const suppressedByTurn = new Map();
+  const unknownTurnWarning =
+    /WARN codex_app_server_protocol::protocol::thread_history: dropping turn-scoped item for unknown turn id `([^`]+)` item_id=/;
+
+  for (const line of lines) {
+    if (line === '') continue;
+    const match = line.match(unknownTurnWarning);
+    if (!match) {
+      out.push(line);
+      continue;
+    }
+
+    const turnId = match[1];
+    const current = suppressedByTurn.get(turnId) ?? { seen: 0, suppressed: 0 };
+    if (current.seen === 0) {
+      out.push(line);
+    } else {
+      current.suppressed++;
+    }
+    current.seen++;
+    suppressedByTurn.set(turnId, current);
+  }
+
+  for (const [turnId, { suppressed }] of suppressedByTurn.entries()) {
+    if (suppressed > 0) {
+      out.push(
+        `[throughline] suppressed ${suppressed} repeated Codex app-server unknown-turn item warnings for turn ${turnId}`,
+      );
+    }
+  }
+
+  return out.length === 0 ? '' : `${out.join('\n')}\n`;
 }
 
 function compactNullish(value) {

--- a/src/codex-app-server.test.mjs
+++ b/src/codex-app-server.test.mjs
@@ -16,6 +16,7 @@ import {
   encodeAppServerMessage,
   parseAppServerLine,
   runCodexTrimPreflight,
+  summarizeAppServerStderr,
 } from './codex-app-server.mjs';
 
 test('encodeAppServerMessage writes one newline-delimited JSON object', () => {
@@ -186,6 +187,26 @@ test('compareTurnCounts: rejects invalid expected turn count', () => {
         resumedTurns: 2,
       }),
     /expectedTurns must be a non-negative integer/,
+  );
+});
+
+test('summarizeAppServerStderr: compacts repeated unknown-turn item warnings', () => {
+  const stderr = [
+    '2026-05-06T00:00:00Z  WARN codex_app_server_protocol::protocol::thread_history: dropping turn-scoped item for unknown turn id `turn-a` item_id="call_1"',
+    '2026-05-06T00:00:01Z  WARN codex_app_server_protocol::protocol::thread_history: dropping turn-scoped item for unknown turn id `turn-a` item_id="call_2"',
+    'unrelated warning',
+    '2026-05-06T00:00:02Z  WARN codex_app_server_protocol::protocol::thread_history: dropping turn-scoped item for unknown turn id `turn-a` item_id="call_3"',
+    '',
+  ].join('\n');
+
+  assert.equal(
+    summarizeAppServerStderr(stderr),
+    [
+      '2026-05-06T00:00:00Z  WARN codex_app_server_protocol::protocol::thread_history: dropping turn-scoped item for unknown turn id `turn-a` item_id="call_1"',
+      'unrelated warning',
+      '[throughline] suppressed 2 repeated Codex app-server unknown-turn item warnings for turn turn-a',
+      '',
+    ].join('\n'),
   );
 });
 


### PR DESCRIPTION
## Summary
- compact repeated Codex app-server unknown-turn item warnings in trim preflight / guarded execute results
- preserve the first warning occurrence and unrelated stderr diagnostics
- document the change in the changelog

## Verification
- npm test
- git diff --check
- read-only current thread preflight JSON: appServerStderrBytes dropped from about 45KB to 340B while turnCountCheck stayed match

Claude remains primary; this does not modify Claude hooks, slash commands, transcript behavior, or user .claude/settings.json.