### PR TITLE
feat: show Codex trim thread env in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ shipped to npm but were not individually tagged on GitHub.
   a current-thread identity signal when `--codex-thread-id` is omitted; the CLI
   flag remains authoritative and Throughline still does not guess from the
   latest rollout.
+- `throughline doctor --trim --host codex` now reports whether a current Codex
+  thread id is available from env and adjusts its dry-run example accordingly.
 - `throughline trim --preflight --host codex --codex-thread-id <id>` now
   performs a guarded Codex app-server initialize/read/resume check and stops
   before sending rollback or inject. When the plan source is `codex-rollout`,

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ mutate the thread if they differ.
 
 ```bash
 throughline doctor --trim --host claude
+throughline doctor --trim --host codex
 printf '**Next move**: continue the current implementation\n' \
   | throughline trim --dry-run --host claude --memo-stdin
 throughline codex-threads --json --limit 5

--- a/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
+++ b/docs/THROUGHLINE_CODEX_TRIM_IMPLEMENTATION_PLAN.md
@@ -448,7 +448,7 @@ Phase 8 partial implementation result (2026-05-06):
 - `codex-rollout` source は `event_msg:task_started` を turn として扱い、`event_msg:thread_rolled_back` を適用して active turns を再構成する。rollback 済み tail は current memory preview に戻さない。
 - Claude slash command [.claude/commands/tl-trim.md](../.claude/commands/tl-trim.md) を追加し、現行 Claude が current-work memo を書いてから `throughline trim --dry-run --host claude --memo-stdin` を呼ぶ dry-run UX にした。
 - `throughline install` / `uninstall` は `/tl-trim` も配布 / 削除する。
-- `throughline doctor --trim --host claude|codex|unknown` を追加し、default keep-recent、automatic rollback / inject 可否、manual procedure を表示する。
+- `throughline doctor --trim --host claude|codex|unknown` を追加し、default keep-recent、automatic rollback / inject 可否、manual procedure を表示する。Codex host では `THROUGHLINE_CODEX_THREAD_ID` / `CODEX_THREAD_ID` の検出結果も表示する。
 - `resume-context` の L2 section を「直近のターン履歴」から「現在進行中の作業履歴 (active work thread)」へ寄せ、読み方の契約を追加した。L2 全体を現在真実とみなすのではなく、古い順の active context として読み、後続行が前の仮説を上書きし得ることを明示する。
 
 Current-work framing research note (2026-05-06):

--- a/src/cli/doctor.mjs
+++ b/src/cli/doctor.mjs
@@ -20,6 +20,7 @@ import { execSync } from 'node:child_process';
 import { getStateDir } from '../state-file.mjs';
 import { readLatestUsage } from '../transcript-usage.mjs';
 import { DEFAULT_TRIM_KEEP_RECENT, describeTrimHost } from '../trim-model.mjs';
+import { resolveCodexThreadIdentity } from '../codex-thread-identity.mjs';
 
 const GREEN = '\x1b[32m✓\x1b[0m';
 const RED = '\x1b[31m✗\x1b[0m';
@@ -276,8 +277,10 @@ function runSessionDiagnosis(prefix) {
   }
 }
 
-function runTrimDiagnosis(host) {
+function runTrimDiagnosis(host, env = process.env) {
   const info = describeTrimHost(host);
+  const codexIdentity =
+    info.host === 'codex' ? resolveCodexThreadIdentity({ codexThreadId: null }, env) : null;
   console.log(`${BOLD}[Trim]${RESET}\n`);
   console.log(`  host:                  ${info.host}`);
   console.log(`  default keep-recent:   ${DEFAULT_TRIM_KEEP_RECENT}`);
@@ -285,9 +288,19 @@ function runTrimDiagnosis(host) {
   console.log(`  automatic inject:      ${info.automaticInject ? 'yes' : 'no'}`);
   console.log(`  boundary status:       ${info.status}`);
   console.log(`  boundary reason:       ${info.reason}`);
+  if (codexIdentity) {
+    const identityText = codexIdentity.codexThreadId
+      ? `${codexIdentity.codexThreadId} (${codexIdentity.codexThreadIdSource})`
+      : 'not detected';
+    console.log(`  current Codex thread:  ${identityText}`);
+  }
   console.log('');
   console.log('  dry-run command:');
-  console.log(`    throughline trim --dry-run --host ${info.host}`);
+  if (info.host === 'codex' && !codexIdentity?.codexThreadId) {
+    console.log('    throughline trim --dry-run --host codex --codex-thread-id <id>');
+  } else {
+    console.log(`    throughline trim --dry-run --host ${info.host}`);
+  }
   console.log('');
   console.log('  manual procedure:');
   for (const step of info.manualProcedure) {

--- a/src/cli/doctor.test.mjs
+++ b/src/cli/doctor.test.mjs
@@ -6,7 +6,8 @@ import { join } from 'node:path';
 
 import { _internal } from './doctor.mjs';
 
-const { parseArgs, formatAgo, formatBytes, findLatestJsonlInSameDir, isPidAlive } = _internal;
+const { parseArgs, formatAgo, formatBytes, findLatestJsonlInSameDir, isPidAlive, runTrimDiagnosis } =
+  _internal;
 
 // ─── parseArgs ──────────────────────────────────────────────────────
 
@@ -42,11 +43,48 @@ test('parseArgs: --host は known host のみ', () => {
   assert.throws(() => parseArgs(['--trim', '--host', 'robot']), /claude, codex, or unknown/);
 });
 
+test('runTrimDiagnosis: codex reports missing current thread identity', () => {
+  const output = captureStdout(() => runTrimDiagnosis('codex', {}));
+
+  assert.match(output, /current Codex thread:\s+not detected/);
+  assert.match(output, /throughline trim --dry-run --host codex --codex-thread-id <id>/);
+});
+
+test('runTrimDiagnosis: codex reports env current thread identity', () => {
+  const output = captureStdout(() =>
+    runTrimDiagnosis('codex', {
+      THROUGHLINE_CODEX_THREAD_ID: '019dfaba-f87e-7f41-a144-d5ca7c6dd7f9',
+    }),
+  );
+
+  assert.match(
+    output,
+    /current Codex thread:\s+019dfaba-f87e-7f41-a144-d5ca7c6dd7f9 \(env:THROUGHLINE_CODEX_THREAD_ID\)/,
+  );
+  assert.match(output, /throughline trim --dry-run --host codex/);
+  assert.doesNotMatch(output, /--codex-thread-id <id>/);
+});
+
 // ─── formatAgo ──────────────────────────────────────────────────────
 
 test('formatAgo: 60 秒未満は秒表示', () => {
   assert.equal(formatAgo(30_000), '30s ago');
 });
+
+function captureStdout(fn) {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let output = '';
+  process.stdout.write = (chunk) => {
+    output += String(chunk);
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return output;
+}
 
 test('formatAgo: 60 分未満は分表示', () => {
   assert.equal(formatAgo(5 * 60_000), '5m ago');

--- a/src/cli/trim.mjs
+++ b/src/cli/trim.mjs
@@ -1,5 +1,6 @@
 import { runCodexTrimExecution, runCodexTrimPreflight } from '../codex-app-server.mjs';
 import { buildCodexRolloutTrimSource } from '../codex-rollout-memory.mjs';
+import { resolveCodexThreadIdentity } from '../codex-thread-identity.mjs';
 import { getDb } from '../db.mjs';
 import {
   DEFAULT_TRIM_KEEP_RECENT,
@@ -283,30 +284,6 @@ function hasInjectableMemory(text) {
 
 function expectedCodexAppServerTurns(plan) {
   return plan?.trim?.source === 'codex-rollout' ? plan.trim.capturedTurns : null;
-}
-
-export function resolveCodexThreadIdentity(parsed, env = process.env) {
-  if (parsed.codexThreadId) {
-    return {
-      codexThreadId: parsed.codexThreadId,
-      codexThreadIdSource: 'arg:--codex-thread-id',
-    };
-  }
-
-  for (const name of ['THROUGHLINE_CODEX_THREAD_ID', 'CODEX_THREAD_ID']) {
-    const value = typeof env[name] === 'string' ? env[name].trim() : '';
-    if (value) {
-      return {
-        codexThreadId: value,
-        codexThreadIdSource: `env:${name}`,
-      };
-    }
-  }
-
-  return {
-    codexThreadId: null,
-    codexThreadIdSource: null,
-  };
 }
 
 function renderTrimActionReport(result) {

--- a/src/codex-thread-identity.mjs
+++ b/src/codex-thread-identity.mjs
@@ -1,0 +1,23 @@
+export function resolveCodexThreadIdentity({ codexThreadId = null } = {}, env = process.env) {
+  if (codexThreadId) {
+    return {
+      codexThreadId,
+      codexThreadIdSource: 'arg:--codex-thread-id',
+    };
+  }
+
+  for (const name of ['THROUGHLINE_CODEX_THREAD_ID', 'CODEX_THREAD_ID']) {
+    const value = typeof env[name] === 'string' ? env[name].trim() : '';
+    if (value) {
+      return {
+        codexThreadId: value,
+        codexThreadIdSource: `env:${name}`,
+      };
+    }
+  }
+
+  return {
+    codexThreadId: null,
+    codexThreadIdSource: null,
+  };
+}


### PR DESCRIPTION
## Summary
- move Codex thread identity resolution into a shared helper
- show detected THROUGHLINE_CODEX_THREAD_ID / CODEX_THREAD_ID in doctor --trim --host codex
- adjust the doctor dry-run example depending on whether a current thread id is detected

## Verification
- npm test
- git diff --check
- doctor --trim --host codex manually prints the env-derived current Codex thread when CODEX_THREAD_ID is present

Claude remains primary; this does not modify Claude hooks, slash commands, transcript behavior, or user .claude/settings.json.